### PR TITLE
Fix missing description for text within CDATA

### DIFF
--- a/src/main/java/com/apptastic/rssreader/RssReader.java
+++ b/src/main/java/com/apptastic/rssreader/RssReader.java
@@ -52,6 +52,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 import java.util.zip.GZIPInputStream;
 
+import static javax.xml.stream.XMLStreamConstants.CDATA;
 import static javax.xml.stream.XMLStreamConstants.CHARACTERS;
 import static javax.xml.stream.XMLStreamConstants.END_ELEMENT;
 import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
@@ -225,7 +226,7 @@ public class RssReader {
                 while (reader.hasNext()) {
                     var type = reader.next(); // do something here
 
-                    if (type == CHARACTERS) {
+                    if (type == CHARACTERS || type == CDATA) {
                         parseCharacters();
                     }
                     else if (type == START_ELEMENT) {


### PR DESCRIPTION
When the descirption is encapsulated within `CDATA`, then the description will be empty. Given the following RSS-feed, the description was empty before this fix:

```xml
<rss xmlns:media="http://search.yahoo.com/mrss/" version="2.0" xmlns:atom="http://www.w3.org/2005/Atom"  xmlns:dc="http://purl.org/dc/elements/1.1/">
	<channel>
		<!-- [...] -->

		<item>
			<title>Am 5. Februar beginnt das Anmeldeverfahren...</title>
			<link>https://www.....</link>
			<description><![CDATA[<p class="bodytext">Die beiden städtischen Gesamtschulen führen ein vorgezogenes Anmeldeverfahren durch.</p>]]></description>
			<pubDate>Mon, 27 Jan 2020 00:00:00 +0000</pubDate>
			<guid>https://www......</guid>
		</item>

<!-- [...] -->
```