### PR TITLE
Datetime format not recognized

### DIFF
--- a/src/main/java/com/apptasticsoftware/rssreader/DateTime.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/DateTime.java
@@ -93,11 +93,10 @@ public class DateTime {
     private static DateTimeFormatter getDateTimeFormatter(String dateTime) {
         if (dateTime.length() >= 29 && dateTime.length() <= 31)
             return DateTimeFormatter.RFC_1123_DATE_TIME;
-        else if (dateTime.length() == 25)
+        else if (dateTime.length() == 20 || dateTime.length() == 25)
             return DateTimeFormatter.ISO_OFFSET_DATE_TIME;
         else if (dateTime.length() == 19)
             return DateTimeFormatter.ISO_LOCAL_DATE_TIME;
-
         return null;
     }
 

--- a/src/test/java/com/apptasticsoftware/rssreader/DateTimeTest.java
+++ b/src/test/java/com/apptasticsoftware/rssreader/DateTimeTest.java
@@ -35,6 +35,12 @@ class DateTimeTest {
     }
 
     @Test
+    void dateTimeFormat5() {
+        Long timestamp = DateTime.toEpochMilli("2021-11-17T13:21:21Z");
+        assertEquals(Long.valueOf(1637155281000L), timestamp);
+    }
+
+    @Test
     void badInputNull() {
         assertNull(DateTime.toLocalDateTime(null));
         assertNull(DateTime.toZonedDateTime(null));


### PR DESCRIPTION
Fixes issue with date time format `2021-11-17T13:21:21Z` throws an exception `Unknown date time format`

This bug only affects code that calls `sorted()` or calls getters that returns `ZonedDateTime`