### PR TITLE
Datetime format not recognized

### DIFF
--- a/src/main/java/com/apptasticsoftware/rssreader/DateTime.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/DateTime.java
@@ -26,14 +26,65 @@ package com.apptasticsoftware.rssreader;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
+import java.time.format.*;
 import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+
+import static java.time.temporal.ChronoField.*;
 
 /**
  * Date Time util class for converting date time strings
  */
 public class DateTime {
     private static ZoneId defaultZone = ZoneId.of("UTC");
+
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_NO_TIMEZONE;
+    static {
+        // manually code maps to ensure correct data always used
+        // (locale data can be changed by application code)
+        Map<Long, String> dow = new HashMap<>();
+        dow.put(1L, "Mon");
+        dow.put(2L, "Tue");
+        dow.put(3L, "Wed");
+        dow.put(4L, "Thu");
+        dow.put(5L, "Fri");
+        dow.put(6L, "Sat");
+        dow.put(7L, "Sun");
+        Map<Long, String> moy = new HashMap<>();
+        moy.put(1L, "Jan");
+        moy.put(2L, "Feb");
+        moy.put(3L, "Mar");
+        moy.put(4L, "Apr");
+        moy.put(5L, "May");
+        moy.put(6L, "Jun");
+        moy.put(7L, "Jul");
+        moy.put(8L, "Aug");
+        moy.put(9L, "Sep");
+        moy.put(10L, "Oct");
+        moy.put(11L, "Nov");
+        moy.put(12L, "Dec");
+        RFC_1123_DATE_TIME_NO_TIMEZONE = new DateTimeFormatterBuilder()
+                .parseCaseInsensitive()
+                .parseLenient()
+                .optionalStart()
+                .appendText(DAY_OF_WEEK, dow)
+                .appendLiteral(", ")
+                .optionalEnd()
+                .appendValue(DAY_OF_MONTH, 1, 2, SignStyle.NOT_NEGATIVE)
+                .appendLiteral(' ')
+                .appendText(MONTH_OF_YEAR, moy)
+                .appendLiteral(' ')
+                .appendValue(YEAR, 4)  // 2 digit year not handled
+                .appendLiteral(' ')
+                .appendValue(HOUR_OF_DAY, 2)
+                .appendLiteral(':')
+                .appendValue(MINUTE_OF_HOUR, 2)
+                .optionalStart()
+                .appendLiteral(':')
+                .appendValue(SECOND_OF_MINUTE, 2)
+                .toFormatter();
+    }
 
     private DateTime() {
 
@@ -76,25 +127,32 @@ public class DateTime {
 
         DateTimeFormatter formatter = getDateTimeFormatter(dateTime);
 
+        if (formatter == null) {
+            throw new IllegalArgumentException("Unknown date time format " + dateTime);
+        }
+
         if (dateTime.length() == 19) {
             // Missing time zone information use default time zone. If not setting any default time zone system default
             // time zone is used.
-            LocalDateTime localDateTime = LocalDateTime.parse(dateTime, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+            LocalDateTime localDateTime = LocalDateTime.parse(dateTime, formatter);
             return ZonedDateTime.of(localDateTime, defaultZone);
-        }
-
-        if (formatter == null) {
-            throw new IllegalArgumentException("Unknown date time format " + dateTime);
+        } else if ((dateTime.length() == 24 || dateTime.length() == 25) && dateTime.charAt(3) == ',') {
+            // Missing time zone information use default time zone. If not setting any default time zone system default
+            // time zone is used.
+            LocalDateTime localDateTime = LocalDateTime.parse(dateTime, formatter);
+            return ZonedDateTime.of(localDateTime, defaultZone);
         }
 
         return ZonedDateTime.parse(dateTime, formatter);
     }
 
     private static DateTimeFormatter getDateTimeFormatter(String dateTime) {
-        if (dateTime.length() >= 29 && dateTime.length() <= 31)
-            return DateTimeFormatter.RFC_1123_DATE_TIME;
-        else if (dateTime.length() == 20 || dateTime.length() == 25)
+        if (dateTime.length() >= 20 && dateTime.length() <= 31 && dateTime.charAt(4) == '-' && dateTime.charAt(10) == 'T')
             return DateTimeFormatter.ISO_OFFSET_DATE_TIME;
+        else if (dateTime.length() >= 29 && dateTime.length() <= 31)
+            return DateTimeFormatter.RFC_1123_DATE_TIME;
+        else if ((dateTime.length() == 24 || dateTime.length() == 25) && dateTime.charAt(3) == ',')
+            return RFC_1123_DATE_TIME_NO_TIMEZONE;
         else if (dateTime.length() == 19)
             return DateTimeFormatter.ISO_LOCAL_DATE_TIME;
         return null;

--- a/src/test/java/com/apptasticsoftware/rssreader/DateTimeTest.java
+++ b/src/test/java/com/apptasticsoftware/rssreader/DateTimeTest.java
@@ -32,12 +32,43 @@ class DateTimeTest {
     void dateTimeFormat4() {
         Long timestamp = DateTime.toEpochMilli("Sat, 30 Nov 2019 08:21:14 GMT");
         assertEquals(Long.valueOf(1575102074000L), timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wed, 02 Oct 2002 13:00:00 GMT");
+        assertEquals(Long.valueOf(1033563600000L), timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wed, 02 Oct 2002 15:00:00 +0200");
+        assertEquals(Long.valueOf(1033563600000L), timestamp);
     }
 
     @Test
     void dateTimeFormat5() {
         Long timestamp = DateTime.toEpochMilli("2021-11-17T13:21:21Z");
         assertEquals(Long.valueOf(1637155281000L), timestamp);
+    }
+
+    @Test
+    void dateTimeFormat6() {
+        Long timestamp = DateTime.toEpochMilli("Sun, 04 Sep 2022 09:42:16");
+        assertEquals(Long.valueOf(1662284536000L), timestamp);
+
+        timestamp = DateTime.toEpochMilli("Sun, 4 Sep 2022 09:42:16");
+        assertEquals(Long.valueOf(1662284536000L), timestamp);
+    }
+
+    @Test
+    void dateTimeFormat7() {
+        //https://datatracker.ietf.org/doc/html/rfc4287#section-3.3
+        Long timestamp = DateTime.toEpochMilli("2003-12-13T18:30:02Z");
+        assertEquals(Long.valueOf(1071340202000L), timestamp);
+
+        timestamp = DateTime.toEpochMilli("2003-12-13T18:30:02.25Z");
+        assertEquals(Long.valueOf(1071340202250L), timestamp);
+
+        timestamp = DateTime.toEpochMilli("2003-12-13T18:30:02+01:00");
+        assertEquals(Long.valueOf(1071336602000L), timestamp);
+
+        timestamp = DateTime.toEpochMilli("2003-12-13T18:30:02.25+01:00");
+        assertEquals(Long.valueOf(1071336602250L), timestamp);
     }
 
     @Test


### PR DESCRIPTION
Fixes issue with date time formats:
`Sun, 04 Sep 2022 09:42:16`
`2003-12-13T18:30:02.25Z`
`2003-12-13T18:30:02.25+01:00`

This bug only affects code that calls `sorted()` or calls getters that returns `ZonedDateTime`