### PR TITLE
addItemExtension not working for tag with no namespace

### DIFF
--- a/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
+++ b/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
@@ -566,11 +566,22 @@ class RssReaderIntegrationTest {
                 .read("https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml")
                 .collect(Collectors.toList());
 
-        int i = 0;
         for (Item item : items) {
-            System.out.println(++i);
             assertThat(item.getChannel().getCategory(), isPresentAndIs("self"));
             assertThat(item.getChannel().getManagingEditor(), isPresentAnd(not(emptyString())));
+            assertThat(item.getAuthor(), isPresentAnd(not(emptyString())));
+        }
+    }
+
+    @Test
+    void testItemExtensionNoNamespace() throws IOException {
+        List<Item> items = new RssReader()
+                .addItemExtension("name", Item::setAuthor)
+                .addItemExtension("email", Item::setAuthor)
+                .read("https://github.com/openjdk/jdk/commits.atom")
+                .collect(Collectors.toList());
+
+        for (Item item : items) {
             assertThat(item.getAuthor(), isPresentAnd(not(emptyString())));
         }
     }


### PR DESCRIPTION
Trying to use addItemExtension() method for a tag with no namespace is not working.

Example:
Author will not be set to the value in name tag.

```java
        List<Item> items = new RssReader()
                .addItemExtension("name", Item::setAuthor)
                .read("https://github.com/openjdk/jdk/commits.atom")
                .collect(Collectors.toList());
```

```xml
  <entry>
    <id>tag:github.com,2008:Grit::Commit/b35922be6de7b848a2982d6a278dbd205fc39e6a</id>
    <link type="text/html" rel="alternate" href="https://github.com/openjdk/jdk/commit/b35922be6de7b848a2982d6a278dbd205fc39e6a"/>
    <title>
        8295714: GHA ::set-output is deprecated and will be removed
    </title>
    <updated>2022-10-21T08:23:45Z</updated>
    <media:thumbnail height="30" width="30" url="https://avatars.githubusercontent.com/u/6209108?s=30&amp;v=4"/>
    <author>
      <name>magicus</name>
      <uri>https://github.com/magicus</uri>
    </author>
    <content type="html">
      &lt;pre style=&#39;white-space:pre-wrap;width:81ex&#39;&gt;8295714: GHA ::set-output is deprecated and will be removed

Reviewed-by: shade&lt;/pre&gt;
    </content>
  </entry>
```