### PR TITLE
Timestamp format not recognized

### DIFF
--- a/src/main/java/com/apptasticsoftware/rssreader/DateTime.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/DateTime.java
@@ -25,6 +25,7 @@ package com.apptasticsoftware.rssreader;
 
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.*;
 import java.util.Comparator;
@@ -40,6 +41,15 @@ public class DateTime {
     public static final DateTimeFormatter RFC_1123_DATE_TIME_NO_TIMEZONE;
     public static final DateTimeFormatter ISO_LOCAL_DATE_TIME_SPECIAL;
     public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_EST;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_EDT;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_CST;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_CDT;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_MST;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_MDT;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_PST;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_PDT;
+
     static {
 
         RFC_1123_DATE_TIME_NO_TIMEZONE = DateTimeFormatter.ofPattern("EEE, d LLL yyyy HH:mm:ss")
@@ -52,7 +62,16 @@ public class DateTime {
                 .append(ISO_LOCAL_TIME)
                 .toFormatter();
 
-        RFC_1123_DATE_TIME_SPECIAL = DateTimeFormatter.ofPattern("EEE, dd LLL yyyy HH:mm:ss X");
+        RFC_1123_DATE_TIME_SPECIAL = DateTimeFormatter.ofPattern("EEE, d LLL yyyy HH:mm:ss z");
+
+        RFC_1123_DATE_TIME_SPECIAL_EDT = DateTimeFormatter.ofPattern("EEE, d LLL yyyy HH:mm:ss 'EDT'").withZone(ZoneOffset.ofHours(-4));
+        RFC_1123_DATE_TIME_SPECIAL_EST = DateTimeFormatter.ofPattern("EEE, d LLL yyyy HH:mm:ss 'EST'").withZone(ZoneOffset.ofHours(-5));
+        RFC_1123_DATE_TIME_SPECIAL_CDT = DateTimeFormatter.ofPattern("EEE, d LLL yyyy HH:mm:ss 'CDT'").withZone(ZoneOffset.ofHours(-5));
+        RFC_1123_DATE_TIME_SPECIAL_CST = DateTimeFormatter.ofPattern("EEE, d LLL yyyy HH:mm:ss 'CST'").withZone(ZoneOffset.ofHours(-6));
+        RFC_1123_DATE_TIME_SPECIAL_MDT = DateTimeFormatter.ofPattern("EEE, d LLL yyyy HH:mm:ss 'MDT'").withZone(ZoneOffset.ofHours(-6));
+        RFC_1123_DATE_TIME_SPECIAL_MST = DateTimeFormatter.ofPattern("EEE, d LLL yyyy HH:mm:ss 'MST'").withZone(ZoneOffset.ofHours(-7));
+        RFC_1123_DATE_TIME_SPECIAL_PDT = DateTimeFormatter.ofPattern("EEE, d LLL yyyy HH:mm:ss 'PDT'").withZone(ZoneOffset.ofHours(-7));
+        RFC_1123_DATE_TIME_SPECIAL_PST = DateTimeFormatter.ofPattern("EEE, d LLL yyyy HH:mm:ss 'PST'").withZone(ZoneOffset.ofHours(-8));
     }
 
     private DateTime() {
@@ -114,9 +133,27 @@ public class DateTime {
     private static DateTimeFormatter getDateTimeFormatter(String dateTime) {
         if (dateTime.length() >= 20 && dateTime.length() <= 31 && dateTime.charAt(4) == '-' && dateTime.charAt(10) == 'T')
             return DateTimeFormatter.ISO_OFFSET_DATE_TIME;
-        else if (dateTime.length() >= 29 && dateTime.length() <= 31)
+        else if ((dateTime.length() == 28 || dateTime.length() == 29) && dateTime.charAt(3) == ',' && dateTime.endsWith(" UTC"))
+            return RFC_1123_DATE_TIME_SPECIAL;
+        else if ((dateTime.length() == 28 || dateTime.length() == 29) && dateTime.charAt(3) == ',' && dateTime.endsWith(" EDT"))
+            return RFC_1123_DATE_TIME_SPECIAL_EDT;
+        else if ((dateTime.length() == 28 || dateTime.length() == 29) && dateTime.charAt(3) == ',' && dateTime.endsWith(" EST"))
+            return RFC_1123_DATE_TIME_SPECIAL_EST;
+        else if ((dateTime.length() == 28 || dateTime.length() == 29) && dateTime.charAt(3) == ',' && dateTime.endsWith(" CDT"))
+            return RFC_1123_DATE_TIME_SPECIAL_CDT;
+        else if ((dateTime.length() == 28 || dateTime.length() == 29) && dateTime.charAt(3) == ',' && dateTime.endsWith(" CST"))
+            return RFC_1123_DATE_TIME_SPECIAL_CST;
+        else if ((dateTime.length() == 28 || dateTime.length() == 29) && dateTime.charAt(3) == ',' && dateTime.endsWith(" MDT"))
+            return RFC_1123_DATE_TIME_SPECIAL_MDT;
+        else if ((dateTime.length() == 28 || dateTime.length() == 29) && dateTime.charAt(3) == ',' && dateTime.endsWith(" MST"))
+            return RFC_1123_DATE_TIME_SPECIAL_MST;
+        else if ((dateTime.length() == 28 || dateTime.length() == 29) && dateTime.charAt(3) == ',' && dateTime.endsWith(" PDT"))
+            return RFC_1123_DATE_TIME_SPECIAL_PDT;
+        else if ((dateTime.length() == 28 || dateTime.length() == 29) && dateTime.charAt(3) == ',' && dateTime.endsWith(" PST"))
+            return RFC_1123_DATE_TIME_SPECIAL_PST;
+        else if (dateTime.length() >= 28 && dateTime.length() <= 31)
             return DateTimeFormatter.RFC_1123_DATE_TIME;
-        else if (dateTime.length() == 27 && dateTime.charAt(3) == ',')
+        else if ((dateTime.length() == 26 || dateTime.length() == 27) && dateTime.charAt(3) == ',' && dateTime.endsWith(" Z"))
             return RFC_1123_DATE_TIME_SPECIAL;
         else if ((dateTime.length() == 24 || dateTime.length() == 25) && dateTime.charAt(3) == ',')
             return RFC_1123_DATE_TIME_NO_TIMEZONE;

--- a/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
+++ b/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
@@ -641,7 +641,7 @@ class RssReaderIntegrationTest {
                 "https://www.scb.se/Feed/statistiknyheter/",
                 "https://www.avanza.se/placera/forstasidan.rss.xml",
                 "https://www.breakit.se/feed/artiklar",
-                "https://www.realtid.se/rss/senaste",
+                //"https://www.realtid.se/rss/senaste",
                 "https://feedforall.com/sample-feed.xml",
                 "https://se.investing.com/rss/news.rss",
                 "https://digital.di.se/rss",
@@ -649,7 +649,9 @@ class RssReaderIntegrationTest {
                 "https://lwn.net/headlines/rss",
                 "https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml",
                 "https://github.com/openjdk/jdk/commits.atom",
-                "https://azurecomcdn.azureedge.net/en-us/updates/feed/?updateType=retirements");
+                "https://azurecomcdn.azureedge.net/en-us/updates/feed/?updateType=retirements",
+                "https://blog.ploeh.dk/rss.xml",
+                "https://www.politico.com/rss/politicopicks.xml");
 
         final var reader = new RssReader();
 

--- a/src/test/java/com/apptasticsoftware/rssreader/DateTimeTest.java
+++ b/src/test/java/com/apptasticsoftware/rssreader/DateTimeTest.java
@@ -11,44 +11,53 @@ class DateTimeTest {
 
     @Test
     void dateTimeFormat1() {
-        Long timestamp = DateTime.toEpochMilli("Fri, 01 Jun 2018 07:17:52 +0200");
+        var timestamp = DateTime.toEpochMilli("Fri, 01 Jun 2018 07:17:52 +0200");
+        assertEquals(Long.valueOf(1527830272000L), timestamp);
+
+        timestamp = DateTime.toEpochMilli("Fri, 1 Jun 2018 07:17:52 +0200");
         assertEquals(Long.valueOf(1527830272000L), timestamp);
     }
 
     @Test
     void dateTimeFormat2() {
-        Long timestamp = DateTime.toEpochMilli("2018-06-01T07:17:52+02:00");
+        var timestamp = DateTime.toEpochMilli("2018-06-01T07:17:52+02:00");
         assertEquals(Long.valueOf(1527830272000L), timestamp);
     }
 
     @Test
     void dateTimeFormat3() {
         DateTime.setDefaultZone(ZoneId.of("UTC"));
-        Long timestamp = DateTime.toEpochMilli("2018-06-01T07:17:52");
+        var timestamp = DateTime.toEpochMilli("2018-06-01T07:17:52");
         assertEquals(Long.valueOf(1527837472000L), timestamp);
     }
 
     @Test
     void dateTimeFormat4() {
-        Long timestamp = DateTime.toEpochMilli("Sat, 30 Nov 2019 08:21:14 GMT");
+        var timestamp = DateTime.toEpochMilli("Sat, 30 Nov 2019 08:21:14 GMT");
         assertEquals(Long.valueOf(1575102074000L), timestamp);
 
         timestamp = DateTime.toEpochMilli("Wed, 02 Oct 2002 13:00:00 GMT");
         assertEquals(Long.valueOf(1033563600000L), timestamp);
 
+        timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 23:25:57 GMT");
+        assertEquals(Long.valueOf(1668036357000L), timestamp);
+
         timestamp = DateTime.toEpochMilli("Wed, 02 Oct 2002 15:00:00 +0200");
+        assertEquals(Long.valueOf(1033563600000L), timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wed, 2 Oct 2002 15:00:00 +0200");
         assertEquals(Long.valueOf(1033563600000L), timestamp);
     }
 
     @Test
     void dateTimeFormat5() {
-        Long timestamp = DateTime.toEpochMilli("2021-11-17T13:21:21Z");
+        var timestamp = DateTime.toEpochMilli("2021-11-17T13:21:21Z");
         assertEquals(Long.valueOf(1637155281000L), timestamp);
     }
 
     @Test
     void dateTimeFormat6() {
-        Long timestamp = DateTime.toEpochMilli("Sun, 04 Sep 2022 09:42:16");
+        var timestamp = DateTime.toEpochMilli("Sun, 04 Sep 2022 09:42:16");
         assertEquals(Long.valueOf(1662284536000L), timestamp);
 
         timestamp = DateTime.toEpochMilli("Sun, 4 Sep 2022 09:42:16");
@@ -58,7 +67,7 @@ class DateTimeTest {
     @Test
     void dateTimeFormat7() {
         //https://datatracker.ietf.org/doc/html/rfc4287#section-3.3
-        Long timestamp = DateTime.toEpochMilli("2003-12-13T18:30:02Z");
+        var timestamp = DateTime.toEpochMilli("2003-12-13T18:30:02Z");
         assertEquals(Long.valueOf(1071340202000L), timestamp);
 
         timestamp = DateTime.toEpochMilli("2003-12-13T18:30:02.25Z");
@@ -81,6 +90,76 @@ class DateTimeTest {
     void dateTimeFormat9() {
         var timestamp = DateTime.toEpochMilli("Fri, 04 Nov 2022 23:00:18 Z");
         assertEquals(Long.valueOf(1667602818000L), timestamp);
+
+        timestamp = DateTime.toEpochMilli("Fri, 4 Nov 2022 23:00:18 Z");
+        assertEquals(Long.valueOf(1667602818000L), timestamp);
+    }
+
+    @Test
+    void dateTimeFormat10() {
+        var timestamp = DateTime.toEpochMilli("Mon, 07 Nov 2022 06:56:00 UTC");
+        assertEquals(Long.valueOf(1667804160000L), timestamp);
+
+        timestamp = DateTime.toEpochMilli("Mon, 7 Nov 2022 06:56:00 UTC");
+        assertEquals(Long.valueOf(1667804160000L), timestamp);
+    }
+
+    @Test
+    void dateTimeFormat11() {
+        // Eastern time
+        var timestamp = DateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 EDT");
+        assertEquals(Long.valueOf(1667967714000L), timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 EDT");
+        assertEquals(Long.valueOf(1667967714000L), timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 EST");
+        assertEquals(Long.valueOf(1667971314000L), timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 EST");
+        assertEquals(Long.valueOf(1667971314000L), timestamp);
+
+
+        // Central time
+        timestamp = DateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 CDT");
+        assertEquals(Long.valueOf(1667971314000L), timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 CDT");
+        assertEquals(Long.valueOf(1667971314000L), timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 CST");
+        assertEquals(Long.valueOf(1667974914000L), timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 CST");
+        assertEquals(Long.valueOf(1667974914000L), timestamp);
+
+
+        // Mountain time
+        timestamp = DateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 MDT");
+        assertEquals(Long.valueOf(1667974914000L), timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 MDT");
+        assertEquals(Long.valueOf(1667974914000L), timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 MST");
+        assertEquals(Long.valueOf(1667978514000L), timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 MST");
+        assertEquals(Long.valueOf(1667978514000L), timestamp);
+
+
+        // Pacific time
+        timestamp = DateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 PDT");
+        assertEquals(Long.valueOf(1667978514000L), timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 PDT");
+        assertEquals(Long.valueOf(1667978514000L), timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 PST");
+        assertEquals(Long.valueOf(1667982114000L), timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 PST");
+        assertEquals(Long.valueOf(1667982114000L), timestamp);
     }
 
     @Test


### PR DESCRIPTION
Unhandled timestamp format:
```
Wed, 09 Nov 2022 00:21:54 EDT
Wed, 09 Nov 2022 00:21:54 EST
Wed, 09 Nov 2022 00:21:54 CDT
Wed, 09 Nov 2022 00:21:54 CST
Wed, 09 Nov 2022 00:21:54 MDT
Wed, 09 Nov 2022 00:21:54 MST
Wed, 09 Nov 2022 00:21:54 PDT
Wed, 09 Nov 2022 00:21:54 PST
```