### PR TITLE
Changed default sort order

### DIFF
--- a/src/main/java/com/apptasticsoftware/rssreader/DateTime.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/DateTime.java
@@ -23,6 +23,8 @@
  */
 package com.apptasticsoftware.rssreader;
 
+import com.apptasticsoftware.rssreader.util.ItemComparator;
+
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -187,11 +189,16 @@ public class DateTime {
         return zonedDateTime.toInstant().toEpochMilli();
     }
 
-
     /**
      * Comparator comparing publication date of Item class. Sorted in ascending order (oldest first)
+     *
+     * @deprecated
+     * This method be removed in a future version.
+     * <p> Use {@link ItemComparator#oldestItemFirst()} instead.
+     *
      * @return comparator
      */
+    @Deprecated()
     public static Comparator<Item> pubDateComparator() {
         return Comparator.comparing(i -> i.getPubDate().map(DateTime::toEpochMilli).orElse(0L));
     }

--- a/src/main/java/com/apptasticsoftware/rssreader/Item.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/Item.java
@@ -24,7 +24,10 @@
 package com.apptasticsoftware.rssreader;
 
 
+import com.apptasticsoftware.rssreader.util.ItemComparator;
+
 import java.time.ZonedDateTime;
+import java.util.Comparator;
 import java.util.Objects;
 import java.util.Optional;
 
@@ -34,6 +37,7 @@ import java.util.Optional;
  * to the full story.
  */
 public class Item implements Comparable<Item> {
+    private static final Comparator<Item> DEFAULT_COMPARATOR = ItemComparator.newestItemFirst();
     private String title;
     private String description;
     private String link;
@@ -270,6 +274,6 @@ public class Item implements Comparable<Item> {
      */
     @Override
     public int compareTo(Item o) {
-        return DateTime.pubDateComparator().compare(this, o);
+        return DEFAULT_COMPARATOR.compare(this, o);
     }
 }

--- a/src/main/java/com/apptasticsoftware/rssreader/util/ItemComparator.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/util/ItemComparator.java
@@ -1,0 +1,44 @@
+package com.apptasticsoftware.rssreader.util;
+
+import com.apptasticsoftware.rssreader.DateTime;
+import com.apptasticsoftware.rssreader.Item;
+
+import java.util.Comparator;
+
+/**
+ * Comparator for sorting item objects.
+ */
+public final class ItemComparator {
+
+    private ItemComparator() {
+
+    }
+
+    /**
+     * Comparator for sorting Items on publication date in ascending order (oldest first)
+     *
+     * @return comparator
+     */
+    public static <I extends Item> Comparator<I> oldestItemFirst() {
+        return Comparator.comparing((I i) -> i.getPubDate().map(DateTime::toEpochMilli).orElse(0L));
+    }
+
+    /**
+     * Comparator for sorting Items on publication date in descending order (newest first)
+     *
+     * @return comparator
+     */
+    public static <I extends Item> Comparator<I> newestItemFirst() {
+        return Comparator.comparing((I i) -> i.getPubDate().map(DateTime::toEpochMilli).orElse(0L)).reversed();
+    }
+
+    /**
+     * Comparator for sorting Items on channel title
+     *
+     * @return comparator
+     */
+    public static <I extends Item> Comparator<I> channelTitle() {
+        return Comparator.comparing((I i) -> i.getChannel().getTitle());
+    }
+
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -31,4 +31,5 @@ module com.apptasticsoftware.rssreader {
     requires java.logging;
 
     exports com.apptasticsoftware.rssreader;
+    exports com.apptasticsoftware.rssreader.util;
 }

--- a/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
+++ b/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
@@ -18,7 +18,6 @@ import java.time.LocalDate;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoField;
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -634,57 +633,6 @@ class RssReaderIntegrationTest {
     }
 
     @Test
-    void testReadAsync() {
-        var urlList = List.of(
-                "https://www.riksbank.se/sv/rss/pressmeddelanden",
-                "https://www.konj.se/4.2de5c57614f808a95afcc13f/12.2de5c57614f808a95afcc354.portlet?state=rss&sv.contenttype=text/xml;charset=UTF-8",
-                "https://www.scb.se/Feed/statistiknyheter/",
-                "https://www.avanza.se/placera/forstasidan.rss.xml",
-                "https://www.breakit.se/feed/artiklar",
-                //"https://www.realtid.se/rss/senaste",
-                "https://feedforall.com/sample-feed.xml",
-                "https://se.investing.com/rss/news.rss",
-                "https://www.di.se/digital/rss",
-                "https://worldoftanks.eu/en/rss/news/",
-                "https://lwn.net/headlines/rss",
-                "https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml",
-                "https://github.com/openjdk/jdk/commits.atom",
-                "https://azurecomcdn.azureedge.net/en-us/updates/feed/?updateType=retirements",
-                "https://blog.ploeh.dk/rss.xml",
-                "https://www.politico.com/rss/politicopicks.xml",
-                "https://www.e1.ru/talk/forum/rss.php?f=86");
-
-        final var reader = new RssReader();
-
-        var timestamps = urlList.stream().parallel()
-                .map(url -> {
-                       try {
-                           return reader.readAsync(url);
-                       } catch (Exception e) {
-                           e.printStackTrace();
-                           return null;
-                       }
-                  })
-                .filter(Objects::nonNull)
-                .flatMap(CompletableFuture::join)
-                .sorted()
-                .map(Item::getPubDateZonedDateTime)
-                .flatMap(Optional::stream)
-                .map(t -> t.toInstant().toEpochMilli())
-                .collect(Collectors.toList());
-
-        assertTrue(timestamps.size() > 10);
-
-        var iter = timestamps.iterator();
-        Long current, previous = iter.next();
-        while (iter.hasNext()) {
-            current = iter.next();
-            assertTrue(previous.compareTo(current) <= 0);
-            previous = current;
-        }
-    }
-
-    @Test
     void testReadFromFile() {
         InputStream is = getClass().getClassLoader().getResourceAsStream("itunes-podcast.xml");
         long count = new RssReader().read(is).count();
@@ -692,7 +640,7 @@ class RssReaderIntegrationTest {
     }
     
     @Test
-    void testFieheInfo() throws IOException {
+    void testBadEnclosureInfo() {
         InputStream is = getClass().getClassLoader().getResourceAsStream("podcast-with-bad-enclosure.xml");
         long count = new RssReader().read(is).count();
         assertEquals(1, count);

--- a/src/test/java/com/apptasticsoftware/integrationtest/SortTest.java
+++ b/src/test/java/com/apptasticsoftware/integrationtest/SortTest.java
@@ -1,0 +1,115 @@
+package com.apptasticsoftware.integrationtest;
+
+import com.apptasticsoftware.rssreader.Item;
+import com.apptasticsoftware.rssreader.RssReader;
+import com.apptasticsoftware.rssreader.util.ItemComparator;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class SortTest {
+
+    @Test
+    void testTimestampSortTest() {
+        var urlList = List.of(
+                "https://www.riksbank.se/sv/rss/pressmeddelanden",
+                "https://www.konj.se/4.2de5c57614f808a95afcc13f/12.2de5c57614f808a95afcc354.portlet?state=rss&sv.contenttype=text/xml;charset=UTF-8",
+                "https://www.scb.se/Feed/statistiknyheter/",
+                "https://www.avanza.se/placera/forstasidan.rss.xml",
+                "https://www.breakit.se/feed/artiklar",
+                "https://feedforall.com/sample-feed.xml",
+                "https://se.investing.com/rss/news.rss",
+                "https://www.di.se/digital/rss",
+                "https://worldoftanks.eu/en/rss/news/",
+                "https://lwn.net/headlines/rss",
+                "https://rss.nytimes.com/services/xml/rss/nyt/HomePage.xml",
+                "https://github.com/openjdk/jdk/commits.atom",
+                "https://azurecomcdn.azureedge.net/en-us/updates/feed/?updateType=retirements",
+                "https://blog.ploeh.dk/rss.xml",
+                "https://www.politico.com/rss/politicopicks.xml",
+                "https://www.e1.ru/talk/forum/rss.php?f=86");
+
+        final var reader = new RssReader();
+
+        var timestamps = urlList.stream().parallel()
+                .map(url -> {
+                    try {
+                        return reader.readAsync(url);
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                        return null;
+                    }
+                })
+                .filter(Objects::nonNull)
+                .flatMap(CompletableFuture::join)
+                .sorted()
+                .map(Item::getPubDateZonedDateTime)
+                .flatMap(Optional::stream)
+                .map(t -> t.toInstant().toEpochMilli())
+                .collect(Collectors.toList());
+
+        assertTrue(timestamps.size() > 10);
+
+        var iter = timestamps.iterator();
+        Long current, previous = iter.next();
+        while (iter.hasNext()) {
+            current = iter.next();
+            assertTrue(previous.compareTo(current) >= 0);
+            previous = current;
+        }
+    }
+
+    @Test
+    void testSortNewestFirst() throws IOException {
+        var list = new RssReader().read("https://lwn.net/headlines/rss")
+                .sorted(ItemComparator.newestItemFirst())
+                .collect(Collectors.toList());
+
+        assertTrue(list.size() > 0);
+
+        var previous = list.get(0);
+        for (Item current : list) {
+            assertTrue(previous.compareTo(current) >= 0);
+            previous = current;
+        }
+    }
+
+    @Test
+    void testSortOldestFirst() throws IOException {
+        var list = new RssReader().read("https://lwn.net/headlines/rss")
+                .sorted(ItemComparator.oldestItemFirst())
+                .collect(Collectors.toList());
+
+        assertTrue(list.size() > 0);
+
+        var previous = list.get(0);
+        for (Item current : list) {
+            assertTrue(previous.compareTo(current) <= 0);
+            previous = current;
+        }
+    }
+
+    @Test
+    void testSortChannelTitle() throws IOException {
+
+        var list = Stream.concat(new RssReader().read("https://lwn.net/headlines/rss"),
+                                           new RssReader().read("https://azurecomcdn.azureedge.net/en-us/updates/feed/?updateType=retirements"))
+                                    .sorted(ItemComparator.channelTitle())
+                                    .collect(Collectors.toList());
+
+        var first = list.get(0);
+        var last = list.get(list.size() - 1);
+        assertNotEquals(first.getChannel().getTitle(), last.getChannel().getTitle());
+        assertTrue(first.getChannel().getTitle().toLowerCase().contains("azure"));
+        assertTrue(last.getChannel().getTitle().toLowerCase().contains("lwn"));
+    }
+}


### PR DESCRIPTION
Changed sort order from oldest publication date first to newest publication date first when using `sort()` methods.

Added comparators for changing sort order.

Oldest publication date first:
```java
List<Item> items = new RssReader()
             .read(URL)
             .sorted(ItemComparator.oldestItemFirst())
             .collect(Collectors.toList());
```

Newest publication date first:
```java
List<Item> items = new RssReader()
             .read(URL)
             .sorted()  // default sort order 
             //.sorted(ItemComparator.newestItemFirst())  // same as explicit sorting on newestItemFirst
             .collect(Collectors.toList());
```
