### PR TITLE
Support for more than one category

### DIFF
--- a/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
@@ -105,7 +105,7 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
         channelTags.put("description", Channel::setDescription);
         channelTags.put("subtitle", Channel::setDescription);
         channelTags.put("link", Channel::setLink);
-        channelTags.put("category", Channel::setCategory);
+        channelTags.put("category", AbstractRssReader::setCategory);
         channelTags.put("language", Channel::setLanguage);
         channelTags.put("copyright", Channel::setCopyright);
         channelTags.put("rights", Channel::setCopyright);
@@ -116,6 +116,11 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
         channelTags.put("updated", Channel::setLastBuildDate);
         channelTags.put("managingEditor", Channel::setManagingEditor);
         channelTags.put("webMaster", Channel::setWebMaster);
+    }
+
+    private static void setCategory(Channel channel, String category) {
+        channel.setCategory(category);
+        channel.addCategory(category);
     }
 
     protected void registerChannelAttributes() {
@@ -132,10 +137,15 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
         itemTags.put("content", Item::setDescription);
         itemTags.put("link", Item::setLink);
         itemTags.put("author", Item::setAuthor);
-        itemTags.put("category", Item::setCategory);
+        itemTags.put("category", AbstractRssReader::setCategory);
         itemTags.put("pubDate", Item::setPubDate);
         itemTags.put("published", Item::setPubDate);
         itemTags.put("updated", (i, v) -> { if (i.getPubDate().isEmpty()) i.setPubDate(v); });
+    }
+
+    private static void setCategory(Item item, String category) {
+        item.setCategory(category);
+        item.addCategory(category);
     }
 
     protected void registerItemAttributes() {

--- a/src/main/java/com/apptasticsoftware/rssreader/Channel.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/Channel.java
@@ -305,24 +305,25 @@ public class Channel {
         if (o == null || getClass() != o.getClass()) return false;
         Channel channel = (Channel) o;
         return Objects.equals(getTitle(), channel.getTitle()) &&
-                Objects.equals(getDescription(), channel.getDescription()) &&
-                Objects.equals(getCategory(), channel.getCategory()) &&
-                Objects.equals(getLanguage(), channel.getLanguage()) &&
-                Objects.equals(getLink(), channel.getLink()) &&
-                Objects.equals(getCopyright(), channel.getCopyright()) &&
-                Objects.equals(getGenerator(), channel.getGenerator()) &&
-                Objects.equals(getTtl(), channel.getTtl()) &&
-                Objects.equals(getPubDate(), channel.getPubDate()) &&
-                Objects.equals(getLastBuildDate(), channel.getLastBuildDate()) &&
-                Objects.equals(getManagingEditor(), channel.getManagingEditor()) &&
-                Objects.equals(getWebMaster(), channel.getWebMaster()) &&
-                Objects.equals(getImage(), channel.getImage());
+               Objects.equals(getDescription(), channel.getDescription()) &&
+               getCategories().equals(channel.getCategories()) &&
+               Objects.equals(getLanguage(), channel.getLanguage()) &&
+               Objects.equals(getLink(), channel.getLink()) &&
+               Objects.equals(getCopyright(), channel.getCopyright()) &&
+               Objects.equals(getGenerator(), channel.getGenerator()) &&
+               Objects.equals(getTtl(), channel.getTtl()) &&
+               Objects.equals(getPubDate(), channel.getPubDate()) &&
+               Objects.equals(getLastBuildDate(), channel.getLastBuildDate()) &&
+               Objects.equals(getManagingEditor(), channel.getManagingEditor()) &&
+               Objects.equals(getWebMaster(), channel.getWebMaster()) &&
+               Objects.equals(getImage(), channel.getImage());
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(getTitle(), getDescription(), getCategory(), getLanguage(), getLink(),
+        return Objects.hash(getTitle(), getDescription(), getCategories(), getLanguage(), getLink(),
                 getCopyright(), getGenerator(), getTtl(), getPubDate(), getLastBuildDate(),
                 getManagingEditor(), getWebMaster(), getImage());
     }
+
 }

--- a/src/main/java/com/apptasticsoftware/rssreader/Channel.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/Channel.java
@@ -23,10 +23,8 @@
  */
 package com.apptasticsoftware.rssreader;
 
-
 import java.time.ZonedDateTime;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * Class representing the RSS channel.
@@ -35,6 +33,7 @@ public class Channel {
     private String title;
     private String description;
     private String category;
+    private final List<String> categories = new ArrayList<>();
     private String language;
     private String link;
     private String copyright;
@@ -80,18 +79,46 @@ public class Channel {
 
     /**
      * Get category for the channel.
+     *
+     * @deprecated
+     * This method be removed in a future version.
+     * <p> Use {@link Channel#getCategories()} instead.
+     *
      * @return category
      */
+    @Deprecated()
     public Optional<String> getCategory() {
         return Optional.ofNullable(category);
     }
 
     /**
      * Set category for the channel.
+     *
+     * @deprecated
+     * This method be removed in a future version.
+     * <p> Use {@link Channel#addCategory(String category)} instead.
+     *
      * @param category channel category
      */
+    @Deprecated()
     public void setCategory(String category) {
         this.category = category;
+    }
+
+    /**
+     * Get categories for the channel.
+     * @return list of categories
+     */
+    public List<String> getCategories() {
+        return Collections.unmodifiableList(categories);
+    }
+
+    /**
+     * Add category for the channel.
+     * @param category channel category
+     */
+    public void addCategory(String category) {
+        categories.add(category);
     }
 
     /**

--- a/src/main/java/com/apptasticsoftware/rssreader/Item.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/Item.java
@@ -27,9 +27,7 @@ package com.apptasticsoftware.rssreader;
 import com.apptasticsoftware.rssreader.util.ItemComparator;
 
 import java.time.ZonedDateTime;
-import java.util.Comparator;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 
 /**
  * Class representing a RSS item. A channel may contain any number of items. An item may represent a "story" -- much
@@ -43,6 +41,7 @@ public class Item implements Comparable<Item> {
     private String link;
     private String author;
     private String category;
+    private final List<String> categories = new ArrayList<>();
     private String guid;
     private Boolean isPermaLink;
     private String pubDate;
@@ -142,8 +141,13 @@ public class Item implements Comparable<Item> {
     /**
      * Get category for item.
      *
+     * @deprecated
+     * This method be removed in a future version.
+     * <p> Use {@link Item#getCategories()} instead.
+     *
      * @return category
      */
+    @Deprecated
     public Optional<String> getCategory() {
         return Optional.ofNullable(category);
     }
@@ -151,10 +155,31 @@ public class Item implements Comparable<Item> {
     /**
      * Set category for item.
      *
+     * @deprecated
+     * This method be removed in a future version.
+     * <p> Use {@link Item#addCategory(String category)} instead.
+     *
      * @param category category
      */
+    @Deprecated
     public void setCategory(String category) {
         this.category = category;
+    }
+
+    /**
+     * Get categories for item.
+     * @return list of categories
+     */
+    public List<String> getCategories() {
+        return Collections.unmodifiableList(categories);
+    }
+
+    /**
+     * Add category for item.
+     * @param category category
+     */
+    public void addCategory(String category) {
+        categories.add(category);
     }
 
     /**

--- a/src/main/java/com/apptasticsoftware/rssreader/Item.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/Item.java
@@ -276,7 +276,7 @@ public class Item implements Comparable<Item> {
                 Objects.equals(getDescription(), item.getDescription()) &&
                 Objects.equals(getLink(), item.getLink()) &&
                 Objects.equals(getAuthor(), item.getAuthor()) &&
-                Objects.equals(getCategory(), item.getCategory()) &&
+                getCategories().equals(item.getCategories()) &&
                 Objects.equals(getGuid(), item.getGuid()) &&
                 Objects.equals(getIsPermaLink(), item.getIsPermaLink()) &&
                 Objects.equals(getPubDate(), item.getPubDate()) &&
@@ -286,8 +286,8 @@ public class Item implements Comparable<Item> {
 
     @Override
     public int hashCode() {
-        return Objects.hash(getTitle(), getDescription(), getLink(), getAuthor(), getCategory(), getGuid(),
-                getIsPermaLink(), getPubDate(), getChannel(), getEnclosure());
+        return Objects.hash(getTitle(), getDescription(), getLink(), getAuthor(), getCategories(),
+                getGuid(), getIsPermaLink(), getPubDate(), getChannel(), getEnclosure());
     }
 
     /**

--- a/src/test/java/com/apptasticsoftware/rssreader/RssReaderTest.java
+++ b/src/test/java/com/apptasticsoftware/rssreader/RssReaderTest.java
@@ -501,8 +501,8 @@ class RssReaderTest {
 
     @Test
     void equalsContract() {
-        EqualsVerifier.simple().forClass(Channel.class).verify();
-        EqualsVerifier.simple().forClass(Item.class).verify();
+        EqualsVerifier.simple().forClass(Channel.class).withIgnoredFields("category").withNonnullFields("categories").verify();
+        EqualsVerifier.simple().forClass(Item.class).withIgnoredFields("category").withNonnullFields("categories").verify();
         EqualsVerifier.simple().forClass(Enclosure.class).verify();
         EqualsVerifier.simple().forClass(Image.class).verify();
     }

--- a/src/test/resources/multiple-categories.xml
+++ b/src/test/resources/multiple-categories.xml
@@ -1,0 +1,33 @@
+<rss version="2.0">
+    <channel>
+        <title>NYT > Top Stories</title>
+        <link>https://www.nytimes.com</link>
+        <description/>
+        <language>en-us</language>
+        <copyright>Copyright 2022 The New York Times Company</copyright>
+        <lastBuildDate>Sat, 03 Dec 2022 11:41:48 +0000</lastBuildDate>
+        <pubDate>Sat, 03 Dec 2022 11:33:26 +0000</pubDate>
+        <category>News</category>
+        <category>China</category>
+        <image>
+            <title>NYT > Top Stories</title>
+            <url>https://static01.nyt.com/images/misc/NYT_logo_rss_250x40.png</url>
+            <link>https://www.nytimes.com</link>
+        </image>
+        <item>
+            <title>After Fanning Covid Fears, China Must Now Try to Allay Them</title>
+            <link>https://www.nytimes.com/2022/12/03/business/china-zero-covid.html</link>
+            <guid isPermaLink="true">https://www.nytimes.com/2022/12/03/business/china-zero-covid.html</guid>
+            <description>Beijing had long warned that the only effective response was testing, quarantine and lockdowns. As it shifts policy, it must change how it portrays the risks.</description>
+            <pubDate>Sat, 03 Dec 2022 10:02:47 +0000</pubDate>
+            <category>Beijing (China)</category>
+            <category>China</category>
+            <category>Guangxi (China)</category>
+            <category>Guangzhou (China)</category>
+            <category>Coronavirus (2019-nCoV)</category>
+            <category>Politics and Government</category>
+            <category>Quarantines</category>
+            <category>Propaganda</category>
+        </item>
+    </channel>
+</rss>


### PR DESCRIPTION
Added getCategories() method in Channel and Item classes that returns a list of categories. 
```java
List<String> getCategories()
```
Deprecated method `String getCategory()`.