### PR TITLE
Exception when parsing timestamp with incorrect day of week

### DIFF
--- a/src/main/java/com/apptasticsoftware/rssreader/DateTime.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/DateTime.java
@@ -38,12 +38,14 @@ import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
 /**
  * Date Time util class for converting date time strings
  */
-public class DateTime {
+public final class DateTime {
     private static ZoneId defaultZone = ZoneId.of("UTC");
-    public static final DateTimeFormatter RFC_1123_DATE_TIME_NO_TIMEZONE;
     public static final DateTimeFormatter ISO_LOCAL_DATE_TIME_SPECIAL;
+
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_NO_TIMEZONE;
     public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL;
     public static final DateTimeFormatter RFC_1123_DATE_TIME_GMT_OFFSET;
+    public static final DateTimeFormatter RFC_822_DATE_TIME;
     public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_EST;
     public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_EDT;
     public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_CST;
@@ -52,13 +54,32 @@ public class DateTime {
     public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_MDT;
     public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_PST;
     public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_PDT;
-    public static final DateTimeFormatter RFC_822_DATE_TIME;
+
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_FULL_EOW;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_GMT_OFFSET_FULL_EOW;
+    public static final DateTimeFormatter RFC_822_DATE_TIME_FULL_EOW;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_EST_FULL_EOW;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_EDT_FULL_EOW;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_CST_FULL_EOW;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_CDT_FULL_EOW;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_MST_FULL_EOW;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_MDT_FULL_EOW;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_PST_FULL_EOW;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_PDT_FULL_EOW;
+
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_NO_EOW;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_GMT_OFFSET_NO_EOW;
+    public static final DateTimeFormatter RFC_822_DATE_TIME_NO_EOW;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_EST_NO_EOW;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_EDT_NO_EOW;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_CST_NO_EOW;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_CDT_NO_EOW;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_MST_NO_EOW;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_MDT_NO_EOW;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_PST_NO_EOW;
+    public static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_PDT_NO_EOW;
 
     static {
-
-        RFC_1123_DATE_TIME_NO_TIMEZONE = DateTimeFormatter.ofPattern("EEE, d LLL yyyy HH:mm:ss")
-                                                          .withZone(ZoneId.of("UTC"));
-
         ISO_LOCAL_DATE_TIME_SPECIAL = new DateTimeFormatterBuilder()
                 .parseCaseInsensitive()
                 .append(ISO_LOCAL_DATE)
@@ -66,18 +87,42 @@ public class DateTime {
                 .append(ISO_LOCAL_TIME)
                 .toFormatter();
 
-        RFC_1123_DATE_TIME_SPECIAL = DateTimeFormatter.ofPattern("EEE, d LLL yyyy HH:mm:ss z");
-        RFC_1123_DATE_TIME_GMT_OFFSET = DateTimeFormatter.ofPattern("EEE, d LLL yyyy HH:mm:ss O");
-        RFC_1123_DATE_TIME_SPECIAL_EDT = DateTimeFormatter.ofPattern("EEE, d LLL yyyy HH:mm:ss 'EDT'").withZone(ZoneOffset.ofHours(-4));
-        RFC_1123_DATE_TIME_SPECIAL_EST = DateTimeFormatter.ofPattern("EEE, d LLL yyyy HH:mm:ss 'EST'").withZone(ZoneOffset.ofHours(-5));
-        RFC_1123_DATE_TIME_SPECIAL_CDT = DateTimeFormatter.ofPattern("EEE, d LLL yyyy HH:mm:ss 'CDT'").withZone(ZoneOffset.ofHours(-5));
-        RFC_1123_DATE_TIME_SPECIAL_CST = DateTimeFormatter.ofPattern("EEE, d LLL yyyy HH:mm:ss 'CST'").withZone(ZoneOffset.ofHours(-6));
-        RFC_1123_DATE_TIME_SPECIAL_MDT = DateTimeFormatter.ofPattern("EEE, d LLL yyyy HH:mm:ss 'MDT'").withZone(ZoneOffset.ofHours(-6));
-        RFC_1123_DATE_TIME_SPECIAL_MST = DateTimeFormatter.ofPattern("EEE, d LLL yyyy HH:mm:ss 'MST'").withZone(ZoneOffset.ofHours(-7));
-        RFC_1123_DATE_TIME_SPECIAL_PDT = DateTimeFormatter.ofPattern("EEE, d LLL yyyy HH:mm:ss 'PDT'").withZone(ZoneOffset.ofHours(-7));
-        RFC_1123_DATE_TIME_SPECIAL_PST = DateTimeFormatter.ofPattern("EEE, d LLL yyyy HH:mm:ss 'PST'").withZone(ZoneOffset.ofHours(-8));
+        RFC_1123_DATE_TIME_NO_TIMEZONE = DateTimeFormatter.ofPattern("E, d LLL yyyy HH:mm:ss").withZone(ZoneId.of("UTC"));
+        RFC_1123_DATE_TIME_SPECIAL = DateTimeFormatter.ofPattern("E, d LLL yyyy HH:mm:ss z");
+        RFC_1123_DATE_TIME_GMT_OFFSET = DateTimeFormatter.ofPattern("E, d LLL yyyy HH:mm:ss O");
+        RFC_822_DATE_TIME = DateTimeFormatter.ofPattern("E, d LLL yy HH:mm:ss X");
+        RFC_1123_DATE_TIME_SPECIAL_EDT = DateTimeFormatter.ofPattern("E, d LLL yyyy HH:mm:ss 'EDT'").withZone(ZoneOffset.ofHours(-4));
+        RFC_1123_DATE_TIME_SPECIAL_EST = DateTimeFormatter.ofPattern("E, d LLL yyyy HH:mm:ss 'EST'").withZone(ZoneOffset.ofHours(-5));
+        RFC_1123_DATE_TIME_SPECIAL_CDT = DateTimeFormatter.ofPattern("E, d LLL yyyy HH:mm:ss 'CDT'").withZone(ZoneOffset.ofHours(-5));
+        RFC_1123_DATE_TIME_SPECIAL_CST = DateTimeFormatter.ofPattern("E, d LLL yyyy HH:mm:ss 'CST'").withZone(ZoneOffset.ofHours(-6));
+        RFC_1123_DATE_TIME_SPECIAL_MDT = DateTimeFormatter.ofPattern("E, d LLL yyyy HH:mm:ss 'MDT'").withZone(ZoneOffset.ofHours(-6));
+        RFC_1123_DATE_TIME_SPECIAL_MST = DateTimeFormatter.ofPattern("E, d LLL yyyy HH:mm:ss 'MST'").withZone(ZoneOffset.ofHours(-7));
+        RFC_1123_DATE_TIME_SPECIAL_PDT = DateTimeFormatter.ofPattern("E, d LLL yyyy HH:mm:ss 'PDT'").withZone(ZoneOffset.ofHours(-7));
+        RFC_1123_DATE_TIME_SPECIAL_PST = DateTimeFormatter.ofPattern("E, d LLL yyyy HH:mm:ss 'PST'").withZone(ZoneOffset.ofHours(-8));
 
-        RFC_822_DATE_TIME = DateTimeFormatter.ofPattern("EEE, d LLL yy HH:mm:ss X");
+        RFC_1123_DATE_TIME_SPECIAL_FULL_EOW = DateTimeFormatter.ofPattern("EEEE, d LLL yyyy HH:mm:ss z");
+        RFC_1123_DATE_TIME_GMT_OFFSET_FULL_EOW = DateTimeFormatter.ofPattern("EEEE, d LLL yyyy HH:mm:ss O");
+        RFC_822_DATE_TIME_FULL_EOW = DateTimeFormatter.ofPattern("EEEE, d LLL yyyy HH:mm:ss X");
+        RFC_1123_DATE_TIME_SPECIAL_EDT_FULL_EOW = DateTimeFormatter.ofPattern("EEEE, d LLL yyyy HH:mm:ss 'EDT'").withZone(ZoneOffset.ofHours(-4));
+        RFC_1123_DATE_TIME_SPECIAL_EST_FULL_EOW = DateTimeFormatter.ofPattern("EEEE, d LLL yyyy HH:mm:ss 'EST'").withZone(ZoneOffset.ofHours(-5));
+        RFC_1123_DATE_TIME_SPECIAL_CDT_FULL_EOW = DateTimeFormatter.ofPattern("EEEE, d LLL yyyy HH:mm:ss 'CDT'").withZone(ZoneOffset.ofHours(-5));
+        RFC_1123_DATE_TIME_SPECIAL_CST_FULL_EOW = DateTimeFormatter.ofPattern("EEEE, d LLL yyyy HH:mm:ss 'CST'").withZone(ZoneOffset.ofHours(-6));
+        RFC_1123_DATE_TIME_SPECIAL_MDT_FULL_EOW = DateTimeFormatter.ofPattern("EEEE, d LLL yyyy HH:mm:ss 'MDT'").withZone(ZoneOffset.ofHours(-6));
+        RFC_1123_DATE_TIME_SPECIAL_MST_FULL_EOW = DateTimeFormatter.ofPattern("EEEE, d LLL yyyy HH:mm:ss 'MST'").withZone(ZoneOffset.ofHours(-7));
+        RFC_1123_DATE_TIME_SPECIAL_PDT_FULL_EOW = DateTimeFormatter.ofPattern("EEEE, d LLL yyyy HH:mm:ss 'PDT'").withZone(ZoneOffset.ofHours(-7));
+        RFC_1123_DATE_TIME_SPECIAL_PST_FULL_EOW = DateTimeFormatter.ofPattern("EEEE, d LLL yyyy HH:mm:ss 'PST'").withZone(ZoneOffset.ofHours(-8));
+
+        RFC_1123_DATE_TIME_SPECIAL_NO_EOW = DateTimeFormatter.ofPattern("d LLL yyyy HH:mm:ss z");
+        RFC_1123_DATE_TIME_GMT_OFFSET_NO_EOW = DateTimeFormatter.ofPattern("d LLL yyyy HH:mm:ss O");
+        RFC_822_DATE_TIME_NO_EOW = DateTimeFormatter.ofPattern("d LLL yyyy HH:mm:ss X");
+        RFC_1123_DATE_TIME_SPECIAL_EDT_NO_EOW = DateTimeFormatter.ofPattern("d LLL yyyy HH:mm:ss 'EDT'").withZone(ZoneOffset.ofHours(-4));
+        RFC_1123_DATE_TIME_SPECIAL_EST_NO_EOW = DateTimeFormatter.ofPattern("d LLL yyyy HH:mm:ss 'EST'").withZone(ZoneOffset.ofHours(-5));
+        RFC_1123_DATE_TIME_SPECIAL_CDT_NO_EOW = DateTimeFormatter.ofPattern("d LLL yyyy HH:mm:ss 'CDT'").withZone(ZoneOffset.ofHours(-5));
+        RFC_1123_DATE_TIME_SPECIAL_CST_NO_EOW = DateTimeFormatter.ofPattern("d LLL yyyy HH:mm:ss 'CST'").withZone(ZoneOffset.ofHours(-6));
+        RFC_1123_DATE_TIME_SPECIAL_MDT_NO_EOW = DateTimeFormatter.ofPattern("d LLL yyyy HH:mm:ss 'MDT'").withZone(ZoneOffset.ofHours(-6));
+        RFC_1123_DATE_TIME_SPECIAL_MST_NO_EOW = DateTimeFormatter.ofPattern("d LLL yyyy HH:mm:ss 'MST'").withZone(ZoneOffset.ofHours(-7));
+        RFC_1123_DATE_TIME_SPECIAL_PDT_NO_EOW = DateTimeFormatter.ofPattern("d LLL yyyy HH:mm:ss 'PDT'").withZone(ZoneOffset.ofHours(-7));
+        RFC_1123_DATE_TIME_SPECIAL_PST_NO_EOW = DateTimeFormatter.ofPattern("d LLL yyyy HH:mm:ss 'PST'").withZone(ZoneOffset.ofHours(-8));
     }
 
     private DateTime() {
@@ -98,16 +143,11 @@ public class DateTime {
      * @return local date time object
      */
     public static LocalDateTime toLocalDateTime(String dateTime) {
-        if (dateTime == null)
+        var zonedDateTime = toZonedDateTime(dateTime);
+        if (zonedDateTime == null) {
             return null;
-
-        DateTimeFormatter formatter = getDateTimeFormatter(dateTime);
-
-        if (formatter == null) {
-            throw new IllegalArgumentException("Unknown date time format " + dateTime);
         }
-
-        return LocalDateTime.parse(dateTime, formatter);
+        return zonedDateTime.toLocalDateTime();
     }
 
     /**
@@ -119,7 +159,7 @@ public class DateTime {
         if (dateTime == null)
             return null;
 
-        DateTimeFormatter formatter = getDateTimeFormatter(dateTime);
+        DateTimeFormatter formatter = getDateTimeFormatter(dateTime, false);
 
         if (formatter == null) {
             throw new IllegalArgumentException("Unknown date time format " + dateTime);
@@ -133,14 +173,55 @@ public class DateTime {
             return ZonedDateTime.of(localDateTime, defaultZone);
         }
 
-        return ZonedDateTime.parse(dateTime, formatter);
+        try {
+            return ZonedDateTime.parse(dateTime, formatter);
+        } catch (DateTimeParseException e) {
+            int index = dateTime.indexOf(',');
+            if (index != -1 && e.getMessage().contains("Conflict found: Field DayOfWeek")) {
+                // Handel date time with incorrect day of week
+                String newDateTime = dateTime.substring(index+1).trim();
+                try {
+                    DateTimeFormatter newFormatter = getDateTimeFormatter(newDateTime, true);
+                    return ZonedDateTime.parse(newDateTime, newFormatter);
+                } catch (DateTimeParseException e2) {
+                    throw e;
+                }
+            } else {
+                throw e;
+            }
+        }
     }
 
     @SuppressWarnings("java:S3776")
-    private static DateTimeFormatter getDateTimeFormatter(String dateTime) {
+    private static DateTimeFormatter getDateTimeFormatter(String dateTime, boolean skipEndOfWeekPart) {
+        if (skipEndOfWeekPart) {
+            return parseRfcDateTimeNoDayOfWeek(dateTime);
+        }
+
+        int index = dateTime.indexOf(',');
+
+        if (index == -1) {
+            return parseIsoDateTime(dateTime);
+        } else if (index <= 3) {
+            return parseRfcDateTime(dateTime);
+        } else {
+            return parseRfcDateTimeFullDayOfWeek(dateTime);
+        }
+    }
+
+    private static DateTimeFormatter parseIsoDateTime(String dateTime) {
         if (dateTime.length() >= 20 && dateTime.length() <= 31 && dateTime.charAt(4) == '-' && dateTime.charAt(10) == 'T')
             return DateTimeFormatter.ISO_OFFSET_DATE_TIME;
-        else if ((dateTime.length() == 28 || dateTime.length() == 29) && dateTime.charAt(3) == ',' && dateTime.endsWith(" UTC"))
+        else if (dateTime.length() == 19 && dateTime.charAt(10) == 'T')
+            return DateTimeFormatter.ISO_LOCAL_DATE_TIME;
+        else if (dateTime.length() == 19 && dateTime.charAt(10) == ' ')
+            return ISO_LOCAL_DATE_TIME_SPECIAL;
+        else
+            return null;
+    }
+
+    private static DateTimeFormatter parseRfcDateTime(String dateTime) {
+        if ((dateTime.length() == 28 || dateTime.length() == 29) && dateTime.charAt(3) == ',' && dateTime.endsWith(" UTC"))
             return RFC_1123_DATE_TIME_SPECIAL;
         else if ((dateTime.length() == 28 || dateTime.length() == 29) && dateTime.charAt(3) == ',' && dateTime.endsWith(" EDT"))
             return RFC_1123_DATE_TIME_SPECIAL_EDT;
@@ -168,11 +249,66 @@ public class DateTime {
             return RFC_1123_DATE_TIME_SPECIAL;
         else if ((dateTime.length() == 24 || dateTime.length() == 25) && dateTime.charAt(3) == ',')
             return RFC_1123_DATE_TIME_NO_TIMEZONE;
-        else if (dateTime.length() == 19 && dateTime.charAt(10) == 'T')
-            return DateTimeFormatter.ISO_LOCAL_DATE_TIME;
-        else if (dateTime.length() == 19 && dateTime.charAt(10) == ' ')
-            return ISO_LOCAL_DATE_TIME_SPECIAL;
-        return null;
+        else
+            return null;
+    }
+
+    private static DateTimeFormatter parseRfcDateTimeFullDayOfWeek (String dateTime) {
+        if (dateTime.endsWith(" UTC"))
+            return RFC_1123_DATE_TIME_SPECIAL_FULL_EOW;
+        else if (dateTime.endsWith(" EDT"))
+            return RFC_1123_DATE_TIME_SPECIAL_EDT_FULL_EOW;
+        else if (dateTime.endsWith(" EST"))
+            return RFC_1123_DATE_TIME_SPECIAL_EST_FULL_EOW;
+        else if (dateTime.endsWith(" CDT"))
+            return RFC_1123_DATE_TIME_SPECIAL_CDT_FULL_EOW;
+        else if (dateTime.endsWith(" CST"))
+            return RFC_1123_DATE_TIME_SPECIAL_CST_FULL_EOW;
+        else if (dateTime.endsWith(" MDT"))
+            return RFC_1123_DATE_TIME_SPECIAL_MDT_FULL_EOW;
+        else if (dateTime.endsWith(" MST"))
+            return RFC_1123_DATE_TIME_SPECIAL_MST_FULL_EOW;
+        else if (dateTime.endsWith(" PDT"))
+            return RFC_1123_DATE_TIME_SPECIAL_PDT_FULL_EOW;
+        else if (dateTime.endsWith(" PST"))
+            return RFC_1123_DATE_TIME_SPECIAL_PST_FULL_EOW;
+        else if (dateTime.contains("GMT"))
+            return RFC_1123_DATE_TIME_GMT_OFFSET_FULL_EOW;
+        else if (dateTime.endsWith(" Z"))
+            return RFC_1123_DATE_TIME_SPECIAL_FULL_EOW;
+        else if (dateTime.contains("-") ||dateTime.contains("+"))
+            return RFC_822_DATE_TIME_FULL_EOW;
+        else
+            return null;
+    }
+
+    private static DateTimeFormatter parseRfcDateTimeNoDayOfWeek (String dateTime) {
+        if (dateTime.endsWith(" UTC"))
+            return RFC_1123_DATE_TIME_SPECIAL_NO_EOW;
+        else if (dateTime.endsWith(" EDT"))
+            return RFC_1123_DATE_TIME_SPECIAL_EDT_NO_EOW;
+        else if (dateTime.endsWith(" EST"))
+            return RFC_1123_DATE_TIME_SPECIAL_EST_NO_EOW;
+        else if (dateTime.endsWith(" CDT"))
+            return RFC_1123_DATE_TIME_SPECIAL_CDT_NO_EOW;
+        else if (dateTime.endsWith(" CST"))
+            return RFC_1123_DATE_TIME_SPECIAL_CST_NO_EOW;
+        else if (dateTime.endsWith(" MDT"))
+            return RFC_1123_DATE_TIME_SPECIAL_MDT_NO_EOW;
+        else if (dateTime.endsWith(" MST"))
+            return RFC_1123_DATE_TIME_SPECIAL_MST_NO_EOW;
+        else if (dateTime.endsWith(" PDT"))
+            return RFC_1123_DATE_TIME_SPECIAL_PDT_NO_EOW;
+        else if (dateTime.endsWith(" PST"))
+            return RFC_1123_DATE_TIME_SPECIAL_PST_NO_EOW;
+        else if (dateTime.contains("GMT"))
+            return RFC_1123_DATE_TIME_GMT_OFFSET_NO_EOW;
+        else if (dateTime.endsWith(" Z"))
+            return RFC_1123_DATE_TIME_SPECIAL_NO_EOW;
+        else if (dateTime.contains("-") ||dateTime.contains("+"))
+            return RFC_822_DATE_TIME_NO_EOW;
+        else
+            return null;
     }
 
     /**

--- a/src/test/java/com/apptasticsoftware/rssreader/DateTimeTest.java
+++ b/src/test/java/com/apptasticsoftware/rssreader/DateTimeTest.java
@@ -12,166 +12,232 @@ class DateTimeTest {
     @Test
     void dateTimeFormat1() {
         var timestamp = DateTime.toEpochMilli("Fri, 01 Jun 2018 07:17:52 +0200");
-        assertEquals(Long.valueOf(1527830272000L), timestamp);
+        assertEquals(1527830272000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("Fri, 1 Jun 2018 07:17:52 +0200");
-        assertEquals(Long.valueOf(1527830272000L), timestamp);
+        assertEquals(1527830272000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("Wed, 02 Oct 2002 15:00:00 +0200");
-        assertEquals(Long.valueOf(1033563600000L), timestamp);
+        assertEquals(1033563600000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("Wed, 2 Oct 2002 15:00:00 +0200");
-        assertEquals(Long.valueOf(1033563600000L), timestamp);
+        assertEquals(1033563600000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("Thu, 02 Jun 22 07:46:24 +0000");
-        assertEquals(Long.valueOf(1654155984000L), timestamp);
+        assertEquals(1654155984000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("Thu, 2 Jun 22 07:46:24 +0000");
-        assertEquals(Long.valueOf(1654155984000L), timestamp);
+        assertEquals(1654155984000L, timestamp);
     }
 
     @Test
     void dateTimeFormat2() {
         var timestamp = DateTime.toEpochMilli("2018-06-01T07:17:52+02:00");
-        assertEquals(Long.valueOf(1527830272000L), timestamp);
+        assertEquals(1527830272000L, timestamp);
     }
 
     @Test
     void dateTimeFormat3() {
         DateTime.setDefaultZone(ZoneId.of("UTC"));
         var timestamp = DateTime.toEpochMilli("2018-06-01T07:17:52");
-        assertEquals(Long.valueOf(1527837472000L), timestamp);
+        assertEquals(1527837472000L, timestamp);
     }
 
     @Test
     void dateTimeFormat4() {
         var timestamp = DateTime.toEpochMilli("Sat, 30 Nov 2019 08:21:14 GMT");
-        assertEquals(Long.valueOf(1575102074000L), timestamp);
+        assertEquals(1575102074000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("Wed, 02 Oct 2002 13:00:00 GMT");
-        assertEquals(Long.valueOf(1033563600000L), timestamp);
+        assertEquals(1033563600000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 23:25:57 GMT");
-        assertEquals(Long.valueOf(1668036357000L), timestamp);
+        assertEquals(1668036357000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("Wed, 15 Jan 2020 10:13:32 GMT+6");
-        assertEquals(Long.valueOf(1579061612000L), timestamp);
+        assertEquals(1579061612000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("Wed, 15 Jan 2020 10:13:32 GMT+06:00");
-        assertEquals(Long.valueOf(1579061612000L), timestamp);
+        assertEquals(1579061612000L, timestamp);
     }
 
     @Test
     void dateTimeFormat5() {
         var timestamp = DateTime.toEpochMilli("2021-11-17T13:21:21Z");
-        assertEquals(Long.valueOf(1637155281000L), timestamp);
+        assertEquals(1637155281000L, timestamp);
     }
 
     @Test
     void dateTimeFormat6() {
         var timestamp = DateTime.toEpochMilli("Sun, 04 Sep 2022 09:42:16");
-        assertEquals(Long.valueOf(1662284536000L), timestamp);
+        assertEquals(1662284536000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("Sun, 4 Sep 2022 09:42:16");
-        assertEquals(Long.valueOf(1662284536000L), timestamp);
+        assertEquals(1662284536000L, timestamp);
     }
 
     @Test
     void dateTimeFormat7() {
         //https://datatracker.ietf.org/doc/html/rfc4287#section-3.3
         var timestamp = DateTime.toEpochMilli("2003-12-13T18:30:02Z");
-        assertEquals(Long.valueOf(1071340202000L), timestamp);
+        assertEquals(1071340202000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("2003-12-13T18:30:02.25Z");
-        assertEquals(Long.valueOf(1071340202250L), timestamp);
+        assertEquals(1071340202250L, timestamp);
 
         timestamp = DateTime.toEpochMilli("2003-12-13T18:30:02+01:00");
-        assertEquals(Long.valueOf(1071336602000L), timestamp);
+        assertEquals(1071336602000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("2003-12-13T18:30:02.25+01:00");
-        assertEquals(Long.valueOf(1071336602250L), timestamp);
+        assertEquals(1071336602250L, timestamp);
     }
 
     @Test
     void dateTimeFormat8() {
         var timestamp = DateTime.toEpochMilli("2022-10-20 02:10:12");
-        assertEquals(Long.valueOf(1666231812000L), timestamp);
+        assertEquals(1666231812000L, timestamp);
     }
 
     @Test
     void dateTimeFormat9() {
         var timestamp = DateTime.toEpochMilli("Fri, 04 Nov 2022 23:00:18 Z");
-        assertEquals(Long.valueOf(1667602818000L), timestamp);
+        assertEquals(1667602818000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("Fri, 4 Nov 2022 23:00:18 Z");
-        assertEquals(Long.valueOf(1667602818000L), timestamp);
+        assertEquals(1667602818000L, timestamp);
     }
 
     @Test
     void dateTimeFormat10() {
         var timestamp = DateTime.toEpochMilli("Mon, 07 Nov 2022 06:56:00 UTC");
-        assertEquals(Long.valueOf(1667804160000L), timestamp);
+        assertEquals(1667804160000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("Mon, 7 Nov 2022 06:56:00 UTC");
-        assertEquals(Long.valueOf(1667804160000L), timestamp);
+        assertEquals(1667804160000L, timestamp);
     }
 
     @Test
     void dateTimeFormat11() {
         // Eastern time
         var timestamp = DateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 EDT");
-        assertEquals(Long.valueOf(1667967714000L), timestamp);
+        assertEquals(1667967714000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 EDT");
-        assertEquals(Long.valueOf(1667967714000L), timestamp);
+        assertEquals(1667967714000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 EST");
-        assertEquals(Long.valueOf(1667971314000L), timestamp);
+        assertEquals(1667971314000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 EST");
-        assertEquals(Long.valueOf(1667971314000L), timestamp);
+        assertEquals(1667971314000L, timestamp);
 
 
         // Central time
         timestamp = DateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 CDT");
-        assertEquals(Long.valueOf(1667971314000L), timestamp);
+        assertEquals(1667971314000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 CDT");
-        assertEquals(Long.valueOf(1667971314000L), timestamp);
+        assertEquals(1667971314000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 CST");
-        assertEquals(Long.valueOf(1667974914000L), timestamp);
+        assertEquals(1667974914000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 CST");
-        assertEquals(Long.valueOf(1667974914000L), timestamp);
+        assertEquals(1667974914000L, timestamp);
 
 
         // Mountain time
         timestamp = DateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 MDT");
-        assertEquals(Long.valueOf(1667974914000L), timestamp);
+        assertEquals(1667974914000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 MDT");
-        assertEquals(Long.valueOf(1667974914000L), timestamp);
+        assertEquals(1667974914000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 MST");
-        assertEquals(Long.valueOf(1667978514000L), timestamp);
+        assertEquals(1667978514000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 MST");
-        assertEquals(Long.valueOf(1667978514000L), timestamp);
+        assertEquals(1667978514000L, timestamp);
 
 
         // Pacific time
         timestamp = DateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 PDT");
-        assertEquals(Long.valueOf(1667978514000L), timestamp);
+        assertEquals(1667978514000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 PDT");
-        assertEquals(Long.valueOf(1667978514000L), timestamp);
+        assertEquals(1667978514000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 PST");
-        assertEquals(Long.valueOf(1667982114000L), timestamp);
+        assertEquals(1667982114000L, timestamp);
 
         timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 PST");
-        assertEquals(Long.valueOf(1667982114000L), timestamp);
+        assertEquals(1667982114000L, timestamp);
+    }
+
+
+    @Test
+    void dateTimeFormat12() {
+        assertEquals(1423026000000L, DateTime.toEpochMilli("Wednesday, 04 Feb 2015 00:00:00 EST"));
+        // Eastern time
+        var timestamp = DateTime.toEpochMilli("Wednesday, 09 Nov 2022 00:21:54 EDT");
+        assertEquals(1667967714000L, timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wednesday, 9 Nov 2022 00:21:54 EDT");
+        assertEquals(1667967714000L, timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wednesday, 09 Nov 2022 00:21:54 EST");
+        assertEquals(1667971314000L, timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wednesday, 9 Nov 2022 00:21:54 EST");
+        assertEquals(1667971314000L, timestamp);
+
+
+        // Central time
+        timestamp = DateTime.toEpochMilli("Wednesday, 09 Nov 2022 00:21:54 CDT");
+        assertEquals(1667971314000L, timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wednesday, 9 Nov 2022 00:21:54 CDT");
+        assertEquals(1667971314000L, timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wednesday, 09 Nov 2022 00:21:54 CST");
+        assertEquals(1667974914000L, timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wednesday, 9 Nov 2022 00:21:54 CST");
+        assertEquals(1667974914000L, timestamp);
+
+
+        // Mountain time
+        timestamp = DateTime.toEpochMilli("Wednesday, 09 Nov 2022 00:21:54 MDT");
+        assertEquals(1667974914000L, timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wednesday, 9 Nov 2022 00:21:54 MDT");
+        assertEquals(1667974914000L, timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wednesday, 09 Nov 2022 00:21:54 MST");
+        assertEquals(1667978514000L, timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wednesday, 9 Nov 2022 00:21:54 MST");
+        assertEquals(1667978514000L, timestamp);
+
+
+        // Pacific time
+        timestamp = DateTime.toEpochMilli("Wednesday, 09 Nov 2022 00:21:54 PDT");
+        assertEquals(1667978514000L, timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wednesday, 9 Nov 2022 00:21:54 PDT");
+        assertEquals(1667978514000L, timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wednesday, 09 Nov 2022 00:21:54 PST");
+        assertEquals(1667982114000L, timestamp);
+
+        timestamp = DateTime.toEpochMilli("Wednesday, 9 Nov 2022 00:21:54 PST");
+        assertEquals(1667982114000L, timestamp);
+    }
+
+    @Test
+    void testWrongDayOfWeek() {
+        var timestamp = DateTime.toEpochMilli("Tue, 23 May 2019 02:00:00 -0700");
+        assertEquals(1558602000000L, timestamp);
     }
 
     @Test


### PR DESCRIPTION
An exception is thrown when parsing timestamp with incorrect day-of-week.
Example:
Timestamp Tue, 23 May 2019 02:00:00 -0700. Day of week should be Thursday and no Tuesday.

Solution: Parse timestamp without day-of-week part if an exception is thrown due to incorrect day-of-week.



