### PR TITLE
Fix RssReader not being initialized on readAsync calls

### DIFF
--- a/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
@@ -291,11 +291,6 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
     public Stream<I> read(String url) throws IOException {
         Objects.requireNonNull(url, "URL must not be null");
 
-        if (!isInitialized) {
-            initialize();
-            isInitialized = true;
-        }
-
         try {
             return readAsync(url).get(1, TimeUnit.MINUTES);
         } catch (CompletionException e) {
@@ -321,11 +316,6 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
      */
     public Stream<Item> read(Collection<String> urls) {
         Objects.requireNonNull(urls, "URLs collection must not be null");
-
-        if (!isInitialized) {
-            initialize();
-            isInitialized = true;
-        }
 
         return urls.stream().parallel()
                    .map(url -> {
@@ -376,6 +366,12 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
      */
     public CompletableFuture<Stream<I>> readAsync(String url) {
         Objects.requireNonNull(url, "URL must not be null");
+
+        if (!isInitialized) {
+            initialize();
+            isInitialized = true;
+        }
+
         return sendAsyncRequest(url).thenApply(processResponse());
     }
 


### PR DESCRIPTION
#59 introduced a regression where calling `readAsync` (without calling `read` first) will cause all data to be empty/null.

This PR moves the `initialize` call to `readAsync`, because each function eventually calls into that anyway.
The only exception to this is the `read(InputStream)` overload, so it remains unchanged.