### PR TITLE
Support for custom timestamp parser

### DIFF
--- a/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
@@ -60,6 +60,7 @@ import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
 public abstract class AbstractRssReader<C extends Channel, I extends Item> {
     private static final String LOG_GROUP = "com.apptasticsoftware.rssreader";
     private final HttpClient httpClient;
+    private DateTimeParser dateTimeParser = new DateTime();
     private String userAgent = "";
     private final Map<String, String> headers = new HashMap<>();
     private final HashMap<String, BiConsumer<C, String>> channelTags = new HashMap<>();
@@ -191,6 +192,22 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
     }
 
     /**
+     * Date and Time parser for parsing timestamps.
+     * @param dateTimeParser the date time parser to use.
+     * @return updated RSSReader.
+     */
+    public AbstractRssReader<C, I> setDateTimeParser(DateTimeParser dateTimeParser) {
+        Objects.requireNonNull(dateTimeParser, "Date time parser must not be null");
+
+        this.dateTimeParser = dateTimeParser;
+        return this;
+    }
+
+    protected DateTimeParser getDateTimeParser() {
+        return dateTimeParser;
+    }
+
+    /**
      * Sets the user-agent of the HttpClient.
      * This is completely optional and if not set then it will not send a user-agent header.
      * @param userAgent the user-agent to use.
@@ -204,7 +221,7 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
     }
 
     /**
-     * Adds a header to the HttpClient.
+     * Adds a http header to the HttpClient.
      * This is completely optional and if no headers are set then it will not add anything.
      * @param key the key name of the header.
      * @param value the value of the header.

--- a/src/main/java/com/apptasticsoftware/rssreader/Channel.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/Channel.java
@@ -46,6 +46,15 @@ public class Channel {
     private String docs;
     private String rating;
     private Image image;
+    private final DateTimeParser dateTimeParser;
+
+    public Channel() {
+        dateTimeParser = new DateTime();
+    }
+
+    public Channel(DateTimeParser dateTimeParser) {
+        this.dateTimeParser = dateTimeParser;
+    }
 
     /**
      * Get the name of the channel. It's how people refer to your service. If you have an HTML website that contains the same information as your RSS file, the title of your channel should be the same as the title of your website.
@@ -221,7 +230,7 @@ public class Channel {
      * @return publication date
      */
     public Optional<ZonedDateTime> getPubDateZonedDateTime() {
-        return getPubDate().map(DateTime::toZonedDateTime);
+        return getPubDate().map(dateTimeParser::parse);
     }
 
     /**
@@ -245,7 +254,7 @@ public class Channel {
      * @return last build date
      */
     public Optional<ZonedDateTime> getLastBuildDateZonedDateTime() {
-        return getLastBuildDate().map(DateTime::toZonedDateTime);
+        return getLastBuildDate().map(dateTimeParser::parse);
     }
 
     /**

--- a/src/main/java/com/apptasticsoftware/rssreader/DateTime.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/DateTime.java
@@ -35,8 +35,8 @@ import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
 /**
  * Date Time util class for converting date time strings
  */
-public final class DateTime {
-    private static ZoneId defaultZone = ZoneId.of("UTC");
+public class DateTime implements DateTimeParser {
+    public static ZoneId defaultZone = ZoneId.of("UTC");
 
     public static final DateTimeFormatter BASIC_ISO_DATE;
     public static final DateTimeFormatter ISO_LOCAL_DATE;
@@ -136,7 +136,7 @@ public final class DateTime {
         RFC_1123_DATE_TIME_SPECIAL_PST_NO_EOW = DateTimeFormatter.ofPattern("d LLL yyyy HH:mm:ss 'PST'", Locale.ENGLISH).withZone(ZoneOffset.ofHours(-8));
     }
 
-    private DateTime() {
+    public DateTime() {
 
     }
 
@@ -177,12 +177,14 @@ public final class DateTime {
             throw new IllegalArgumentException("Unknown date time format " + dateTime);
         }
 
-        if (dateTime.length() == 19 || ((dateTime.length() == 29 || dateTime.length() == 32 || dateTime.length() == 35) && dateTime.charAt(10) == 'T') ||
-            ((dateTime.length() == 24 || dateTime.length() == 25) && dateTime.charAt(3) == ',')) {
+        if (dateTime.length() == 19) {
             // Missing time zone information use default time zone. If not setting any default time zone system default
             // time zone is used.
             LocalDateTime localDateTime = LocalDateTime.parse(dateTime, formatter);
             return ZonedDateTime.of(localDateTime, defaultZone);
+        } else if (((dateTime.length() == 29 || dateTime.length() == 32 || dateTime.length() == 35) && dateTime.charAt(10) == 'T') ||
+            ((dateTime.length() == 24 || dateTime.length() == 25) && dateTime.charAt(3) == ',')) {
+            return ZonedDateTime.parse(dateTime, formatter);
         }
 
         try {
@@ -387,4 +389,13 @@ public final class DateTime {
         return Comparator.comparing(i -> i.getPubDate().map(DateTime::toInstant).orElse(Instant.EPOCH));
     }
 
+    /**
+     * Converts a timestamp in String format to a ZonedDateTime
+     * @param timestamp timestamp
+     * @return ZonedDateTime
+     */
+    @Override
+    public ZonedDateTime parse(String timestamp) {
+        return DateTime.toZonedDateTime(timestamp);
+    }
 }

--- a/src/main/java/com/apptasticsoftware/rssreader/DateTimeParser.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/DateTimeParser.java
@@ -23,29 +23,17 @@
  */
 package com.apptasticsoftware.rssreader;
 
-import java.net.http.HttpClient;
+import java.time.ZonedDateTime;
 
 /**
- * Class for reading RSS (Rich Site Summary) and Atom types of web feeds.
+ * For parsing timestamp in channel and items.
  */
-public class RssReader extends AbstractRssReader<Channel, Item> {
+public interface DateTimeParser {
 
-    public RssReader() {
-        super();
-    }
-
-    public RssReader(HttpClient httpClient) {
-        super(httpClient);
-    }
-
-    @Override
-    protected Channel createChannel() {
-        return new Channel(getDateTimeParser());
-    }
-
-    @Override
-    protected Item createItem() {
-        return new Item(getDateTimeParser());
-    }
-
+    /**
+     * Converts a timestamp in String format to a ZonedDateTime
+     * @param timestamp timestamp
+     * @return ZonedDateTime
+     */
+    ZonedDateTime parse(String timestamp);
 }

--- a/src/main/java/com/apptasticsoftware/rssreader/Item.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/Item.java
@@ -35,7 +35,7 @@ import java.util.*;
  * to the full story.
  */
 public class Item implements Comparable<Item> {
-    private static final Comparator<Item> DEFAULT_COMPARATOR = ItemComparator.newestItemFirst();
+    private final Comparator<Item> defaultComparator;
     private String title;
     private String description;
     private String link;
@@ -48,6 +48,17 @@ public class Item implements Comparable<Item> {
     private String comments;
     private Enclosure enclosure;
     private Channel channel;
+    private final DateTimeParser dateTimeParser;
+
+    public Item() {
+        dateTimeParser = new DateTime();
+        defaultComparator = ItemComparator.newestItemFirst();
+    }
+
+    public Item(DateTimeParser dateTimeParser) {
+        this.dateTimeParser = dateTimeParser;
+        defaultComparator = ItemComparator.newestItemFirst(dateTimeParser);
+    }
 
     /**
      * Get the title of the item.
@@ -232,9 +243,8 @@ public class Item implements Comparable<Item> {
      * @return publication date
      */
     public Optional<ZonedDateTime> getPubDateZonedDateTime() {
-        return getPubDate().map(DateTime::toZonedDateTime);
+        return getPubDate().map(dateTimeParser::parse);
     }
-
 
     /**
      * Get comments relating to the item.
@@ -321,6 +331,6 @@ public class Item implements Comparable<Item> {
      */
     @Override
     public int compareTo(Item o) {
-        return DEFAULT_COMPARATOR.compare(this, o);
+        return defaultComparator.compare(this, o);
     }
 }

--- a/src/main/java/com/apptasticsoftware/rssreader/module/itunes/ItunesChannel.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/module/itunes/ItunesChannel.java
@@ -1,6 +1,7 @@
 package com.apptasticsoftware.rssreader.module.itunes;
 
 import com.apptasticsoftware.rssreader.Channel;
+import com.apptasticsoftware.rssreader.DateTimeParser;
 
 import java.util.*;
 
@@ -21,6 +22,10 @@ public class ItunesChannel extends Channel {
     private String itunesNewFeedUrl;
     private boolean itunesBlock;
     private boolean itunesComplete;
+
+    public ItunesChannel(DateTimeParser dateTimeParser) {
+        super(dateTimeParser);
+    }
 
     /**
      * Get the artwork for the show.

--- a/src/main/java/com/apptasticsoftware/rssreader/module/itunes/ItunesItem.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/module/itunes/ItunesItem.java
@@ -1,5 +1,6 @@
 package com.apptasticsoftware.rssreader.module.itunes;
 
+import com.apptasticsoftware.rssreader.DateTimeParser;
 import com.apptasticsoftware.rssreader.Item;
 
 import java.time.Duration;
@@ -21,6 +22,10 @@ public class ItunesItem extends Item {
     private Integer itunesSeason;
     private String itunesEpisodeType;
     private boolean itunesBlock;
+
+    public ItunesItem(DateTimeParser dateTimeParser) {
+        super(dateTimeParser);
+    }
 
     /**
      * Get the duration of an episode.

--- a/src/main/java/com/apptasticsoftware/rssreader/module/itunes/ItunesRssReader.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/module/itunes/ItunesRssReader.java
@@ -59,11 +59,11 @@ public class ItunesRssReader extends AbstractRssReader<ItunesChannel, ItunesItem
 
     @Override
     protected ItunesChannel createChannel() {
-        return new ItunesChannel();
+        return new ItunesChannel(getDateTimeParser());
     }
 
     @Override
     protected ItunesItem createItem() {
-        return new ItunesItem();
+        return new ItunesItem(getDateTimeParser());
     }
 }

--- a/src/main/java/com/apptasticsoftware/rssreader/util/ItemComparator.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/util/ItemComparator.java
@@ -1,10 +1,13 @@
 package com.apptasticsoftware.rssreader.util;
 
 import com.apptasticsoftware.rssreader.DateTime;
+import com.apptasticsoftware.rssreader.DateTimeParser;
 import com.apptasticsoftware.rssreader.Item;
 
 import java.time.Instant;
+import java.time.ZonedDateTime;
 import java.util.Comparator;
+import java.util.Objects;
 
 /**
  * Comparator for sorting item objects.
@@ -25,12 +28,34 @@ public final class ItemComparator {
     }
 
     /**
+     * Comparator for sorting Items on publication date in ascending order (oldest first)
+     * @param <I> any class that extend Item
+     * @param dateTimeParser date time parser
+     * @return comparator
+     */
+    public static <I extends Item> Comparator<I> oldestItemFirst(DateTimeParser dateTimeParser) {
+        Objects.requireNonNull(dateTimeParser, "Date time parser must not be null");
+        return Comparator.comparing((I i) -> i.getPubDate().map(dateTimeParser::parse).map(ZonedDateTime::toInstant).orElse(Instant.EPOCH));
+    }
+
+    /**
      * Comparator for sorting Items on publication date in descending order (newest first)
      * @param <I> any class that extend Item
      * @return comparator
      */
     public static <I extends Item> Comparator<I> newestItemFirst() {
         return Comparator.comparing((I i) -> i.getPubDate().map(DateTime::toInstant).orElse(Instant.EPOCH)).reversed();
+    }
+
+    /**
+     * Comparator for sorting Items on publication date in descending order (newest first)
+     * @param <I> any class that extend Item
+     * @param dateTimeParser date time parser
+     * @return comparator
+     */
+    public static <I extends Item> Comparator<I> newestItemFirst(DateTimeParser dateTimeParser) {
+        Objects.requireNonNull(dateTimeParser, "Date time parser must not be null");
+        return Comparator.comparing((I i) -> i.getPubDate().map(dateTimeParser::parse).map(ZonedDateTime::toInstant).orElse(Instant.EPOCH)).reversed();
     }
 
     /**

--- a/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
+++ b/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
@@ -613,7 +613,7 @@ class RssReaderIntegrationTest {
     void testMultipleCategories() {
         var list = new RssReader().read(fromFile("multiple-categories.xml")).collect(Collectors.toList());
 
-        assertTrue(list.size() > 0);
+        assertFalse(list.isEmpty());
         var item = list.get(0);
         assertTrue(item.getChannel().getCategories().size() > 1);
         assertTrue(item.getChannel().getCategory().isPresent());

--- a/src/test/java/com/apptasticsoftware/integrationtest/SortTest.java
+++ b/src/test/java/com/apptasticsoftware/integrationtest/SortTest.java
@@ -96,9 +96,9 @@ class SortTest {
     void testSortChannelTitle() throws IOException {
 
         var list = Stream.concat(new RssReader().read("https://lwn.net/headlines/rss"),
-                                           new RssReader().read("https://azurecomcdn.azureedge.net/en-us/updates/feed/?updateType=retirements"))
-                                    .sorted(ItemComparator.channelTitle())
-                                    .collect(Collectors.toList());
+                                 new RssReader().read("https://azurecomcdn.azureedge.net/en-us/updates/feed/?updateType=retirements"))
+                         .sorted(ItemComparator.channelTitle())
+                         .collect(Collectors.toList());
 
         var first = list.get(0);
         var last = list.get(list.size() - 1);

--- a/src/test/java/com/apptasticsoftware/rssreader/RssReaderTest.java
+++ b/src/test/java/com/apptasticsoftware/rssreader/RssReaderTest.java
@@ -501,8 +501,8 @@ class RssReaderTest {
 
     @Test
     void equalsContract() {
-        EqualsVerifier.simple().forClass(Channel.class).withIgnoredFields("category").withNonnullFields("categories").verify();
-        EqualsVerifier.simple().forClass(Item.class).withIgnoredFields("category").withNonnullFields("categories").verify();
+        EqualsVerifier.simple().forClass(Channel.class).withIgnoredFields("dateTimeParser").withIgnoredFields("category").withNonnullFields("categories").verify();
+        EqualsVerifier.simple().forClass(Item.class).withIgnoredFields("defaultComparator").withIgnoredFields("dateTimeParser").withIgnoredFields("category").withNonnullFields("categories").verify();
         EqualsVerifier.simple().forClass(Enclosure.class).verify();
         EqualsVerifier.simple().forClass(Image.class).verify();
     }

--- a/src/test/java/com/apptasticsoftware/rssreader/module/itunes/ItunesRssReaderTest.java
+++ b/src/test/java/com/apptasticsoftware/rssreader/module/itunes/ItunesRssReaderTest.java
@@ -1,5 +1,6 @@
 package com.apptasticsoftware.rssreader.module.itunes;
 
+import com.apptasticsoftware.rssreader.DateTime;
 import com.apptasticsoftware.rssreader.util.ItemComparator;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Test;
@@ -31,14 +32,14 @@ class ItunesRssReaderTest {
 
     @Test
     void equalsContract() {
-        EqualsVerifier.simple().forClass(ItunesChannel.class).withIgnoredFields("category").withNonnullFields("categories").withNonnullFields("itunesCategories").verify();
-        EqualsVerifier.simple().forClass(ItunesItem.class).withIgnoredFields("category").withNonnullFields("categories").verify();
+        EqualsVerifier.simple().forClass(ItunesChannel.class).withIgnoredFields("dateTimeParser").withIgnoredFields("category").withNonnullFields("categories").withNonnullFields("itunesCategories").verify();
+        EqualsVerifier.simple().forClass(ItunesItem.class).withIgnoredFields("defaultComparator").withIgnoredFields("dateTimeParser").withIgnoredFields("category").withNonnullFields("categories").verify();
         EqualsVerifier.simple().forClass(ItunesOwner.class).verify();
     }
 
     @Test
     void duration() {
-        ItunesItem item = new ItunesItem();
+        ItunesItem item = new ItunesItem(new DateTime());
         item.setItunesDuration("1");
         assertEquals(1, item.getItunesDurationAsDuration().get().getSeconds());
         item.setItunesDuration("01:02");
@@ -49,7 +50,7 @@ class ItunesRssReaderTest {
 
     @Test
     void badDuration() {
-        ItunesItem item = new ItunesItem();
+        ItunesItem item = new ItunesItem(new DateTime());
         item.setItunesDuration(null);
         assertTrue(item.getItunesDurationAsDuration().isEmpty());
         item.setItunesDuration(" ");


### PR DESCRIPTION
Added `DateTimeParser` interface for parsing custom timestamp.

For parsing non-standard timestamp for example date format in Italy, `dom, 12 mar 2023 12:38:42 GMT`

Usage:
```java
DateTimeParser timestampParserItaly = (timestamp) -> {
    var formatter = DateTimeFormatter.ofPattern("E, d MMM yyy HH:mm:ss z")
                                     .withLocale(Locale.ITALY);
    return ZonedDateTime.parse(timestamp, formatter);
};

var items = new RssReader().setDateTimeParser(timestampParserItaly)
                           .read(URL)
                           .collect(Collectors.toList());
```