### PR TITLE
Allow extension to use full path expression to a node in XML

### DIFF
--- a/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
+++ b/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
@@ -542,13 +542,13 @@ class RssReaderIntegrationTest {
     @Test
     void testItemExtensionNoNamespace() throws IOException {
         List<Item> items = new RssReader()
-                .addItemExtension("name", Item::setAuthor)
-                .addItemExtension("email", Item::setAuthor)
+                .addItemExtension("name", Item::setComments)
+                .addItemExtension("email", Item::setComments)
                 .read("https://github.com/openjdk/jdk/commits.atom")
                 .collect(Collectors.toList());
 
         for (Item item : items) {
-            assertThat(item.getAuthor(), isPresentAnd(not(emptyString())));
+            assertThat(item.getComments(), isPresentAnd(not(emptyString())));
         }
     }
 


### PR DESCRIPTION
For Atom feed `name` element can exist inside both `author` element and `contributor` element.  Allow to use full path expression`/feed/entry/author/name` and `/feed/entry/contributor/name` in extension to distinguish the two apart.

Atom feed example:
```xml
<feed>
...
    <entry>
        <title>An entry from my feed</title>
        <summary>DEFAULT --- This is the default summary</summary>
        <link rel="self" href="/web20/sample_atom_feed/entry" /> 
        <author>
              <name>Joe Bloggs</name>
              <uri>http://www.hursley.ibm.com/JBloggs/</uri>
              <email>JBloggs@uk.ibm.com</email>
        </author>
        <contributor>
              <name>John Doe</name>
        </contributor>
        <category term="Comments" />
        <published>2023-08-10T15:41:00</published>
     </entry>
...
</feed>
```

Custom extension that maps value `Joe Bloggs` to field `Comments` in Item object using full path expression: 
```java
List<Item> items = new RssReader().addItemExtension("/feed/entry/author/name", Item::setComments)
                                  .read(URL)
                                  .collect(Collectors.toList());
```