### PR TITLE
Make it possible to change the default timezone

### DIFF
--- a/src/main/java/com/apptasticsoftware/rssreader/DateTime.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/DateTime.java
@@ -33,10 +33,10 @@ import java.util.Locale;
 import static java.time.format.DateTimeFormatter.ISO_LOCAL_TIME;
 
 /**
- * Date Time util class for converting date time strings
+ * Class for converting date time strings
  */
 public class DateTime implements DateTimeParser {
-    public static ZoneId defaultZone = ZoneId.of("UTC");
+    private final ZoneId defaultZone;
 
     public static final DateTimeFormatter BASIC_ISO_DATE;
     public static final DateTimeFormatter ISO_LOCAL_DATE;
@@ -136,16 +136,20 @@ public class DateTime implements DateTimeParser {
         RFC_1123_DATE_TIME_SPECIAL_PST_NO_EOW = DateTimeFormatter.ofPattern("d LLL yyyy HH:mm:ss 'PST'", Locale.ENGLISH).withZone(ZoneOffset.ofHours(-8));
     }
 
+    /**
+     * Creates DateTime object for converting timestamps.
+     * Using default timezone UTC if no timezone information if found in timestamp.
+     */
     public DateTime() {
-
+        defaultZone = ZoneId.of("UTC");
     }
 
     /**
-     * Time zone to use if now zone information if found in date time string
-     * @param defaultZone time zone to use
+     * Creates DateTime object for converting timestamps.
+     * @param defaultZone time zone to use if no timezone information if found in timestamp
      */
-    public static void setDefaultZone(ZoneId defaultZone) {
-        DateTime.defaultZone = defaultZone;
+    public DateTime(ZoneId defaultZone) {
+        this.defaultZone = defaultZone;
     }
 
     /**
@@ -153,7 +157,7 @@ public class DateTime implements DateTimeParser {
      * @param dateTime date time string
      * @return local date time object
      */
-    public static LocalDateTime toLocalDateTime(String dateTime) {
+    public LocalDateTime toLocalDateTime(String dateTime) {
         var zonedDateTime = toZonedDateTime(dateTime);
         if (zonedDateTime == null) {
             return null;
@@ -167,7 +171,7 @@ public class DateTime implements DateTimeParser {
      * @return zoned date time object
      */
     @SuppressWarnings("java:S3776")
-    public static ZonedDateTime toZonedDateTime(String dateTime) {
+    public ZonedDateTime toZonedDateTime(String dateTime) {
         if (dateTime == null)
             return null;
 
@@ -356,7 +360,7 @@ public class DateTime implements DateTimeParser {
      * @param dateTime date time string
      * @return time in milliseconds
      */
-    public static Long toEpochMilli(String dateTime) {
+    public Long toEpochMilli(String dateTime) {
         ZonedDateTime zonedDateTime = toZonedDateTime(dateTime);
 
         if (zonedDateTime == null)
@@ -365,7 +369,7 @@ public class DateTime implements DateTimeParser {
         return zonedDateTime.toInstant().toEpochMilli();
     }
 
-    public static Instant toInstant(String dateTime) {
+    public Instant toInstant(String dateTime) {
         ZonedDateTime zonedDateTime = toZonedDateTime(dateTime);
 
         if (zonedDateTime == null)
@@ -386,7 +390,8 @@ public class DateTime implements DateTimeParser {
     @SuppressWarnings("java:S1133")
     @Deprecated(since="3.3.0", forRemoval=true)
     public static Comparator<Item> pubDateComparator() {
-        return Comparator.comparing(i -> i.getPubDate().map(DateTime::toInstant).orElse(Instant.EPOCH));
+        var dateTime = new DateTime();
+        return Comparator.comparing(i -> i.getPubDate().map(dateTime::toInstant).orElse(Instant.EPOCH));
     }
 
     /**
@@ -396,6 +401,6 @@ public class DateTime implements DateTimeParser {
      */
     @Override
     public ZonedDateTime parse(String timestamp) {
-        return DateTime.toZonedDateTime(timestamp);
+        return toZonedDateTime(timestamp);
     }
 }

--- a/src/main/java/com/apptasticsoftware/rssreader/util/ItemComparator.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/util/ItemComparator.java
@@ -1,3 +1,26 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2022, Apptastic Software
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
 package com.apptasticsoftware.rssreader.util;
 
 import com.apptasticsoftware.rssreader.DateTime;
@@ -24,7 +47,8 @@ public final class ItemComparator {
      * @return comparator
      */
     public static <I extends Item> Comparator<I> oldestItemFirst() {
-        return Comparator.comparing((I i) -> i.getPubDate().map(DateTime::toInstant).orElse(Instant.EPOCH));
+        var dateTime = new DateTime();
+        return Comparator.comparing((I i) -> i.getPubDate().map(dateTime::toInstant).orElse(Instant.EPOCH));
     }
 
     /**
@@ -44,7 +68,8 @@ public final class ItemComparator {
      * @return comparator
      */
     public static <I extends Item> Comparator<I> newestItemFirst() {
-        return Comparator.comparing((I i) -> i.getPubDate().map(DateTime::toInstant).orElse(Instant.EPOCH)).reversed();
+        var dateTime = new DateTime();
+        return Comparator.comparing((I i) -> i.getPubDate().map(dateTime::toInstant).orElse(Instant.EPOCH)).reversed();
     }
 
     /**

--- a/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
+++ b/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
@@ -418,8 +418,7 @@ class RssReaderIntegrationTest {
         ZonedDateTime dateTime = items.stream()
                                       .sorted()
                                       .findFirst()
-                                      .flatMap(Item::getPubDate)
-                                      .map(DateTime::toZonedDateTime)
+                                      .flatMap(Item::getPubDateZonedDateTime)
                                       .orElse(null);
         assertNotNull(dateTime);
     }
@@ -434,8 +433,7 @@ class RssReaderIntegrationTest {
 
         Optional<ZonedDateTime> dateTime = items.stream()
                                                 .findFirst()
-                                                .flatMap(Item::getPubDate)
-                                                .map(DateTime::toZonedDateTime);
+                                                .flatMap(Item::getPubDateZonedDateTime);
 
         assertThat(dateTime, isPresent());
     }

--- a/src/test/java/com/apptasticsoftware/rssreader/DateTimeTest.java
+++ b/src/test/java/com/apptasticsoftware/rssreader/DateTimeTest.java
@@ -11,388 +11,420 @@ class DateTimeTest {
 
     @Test
     void dateTimeFormat1() {
-        var timestamp = DateTime.toEpochMilli("Fri, 01 Jun 2018 07:17:52 +0200");
+        var dateTime = new DateTime();
+        var timestamp = dateTime.toEpochMilli("Fri, 01 Jun 2018 07:17:52 +0200");
         assertEquals(1527830272000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Fri, 1 Jun 2018 07:17:52 +0200");
+        timestamp = dateTime.toEpochMilli("Fri, 1 Jun 2018 07:17:52 +0200");
         assertEquals(1527830272000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wed, 02 Oct 2002 15:00:00 +0200");
+        timestamp = dateTime.toEpochMilli("Wed, 02 Oct 2002 15:00:00 +0200");
         assertEquals(1033563600000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wed, 2 Oct 2002 15:00:00 +0200");
+        timestamp = dateTime.toEpochMilli("Wed, 2 Oct 2002 15:00:00 +0200");
         assertEquals(1033563600000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Thu, 02 Jun 22 07:46:24 +0000");
+        timestamp = dateTime.toEpochMilli("Thu, 02 Jun 22 07:46:24 +0000");
         assertEquals(1654155984000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Thu, 2 Jun 22 07:46:24 +0000");
+        timestamp = dateTime.toEpochMilli("Thu, 2 Jun 22 07:46:24 +0000");
         assertEquals(1654155984000L, timestamp);
     }
 
     @Test
     void dateTimeFormat2() {
-        var timestamp = DateTime.toEpochMilli("2018-06-01T07:17:52+02:00");
+        var dateTime = new DateTime();
+        var timestamp = dateTime.toEpochMilli("2018-06-01T07:17:52+02:00");
         assertEquals(1527830272000L, timestamp);
     }
 
     @Test
-    void dateTimeFormat3() {
-        DateTime.setDefaultZone(ZoneId.of("UTC"));
-        var timestamp = DateTime.toEpochMilli("2018-06-01T07:17:52");
-        assertEquals(1527837472000L, timestamp);
-    }
-
-    @Test
     void dateTimeFormat4() {
-        var timestamp = DateTime.toEpochMilli("Sat, 30 Nov 2019 08:21:14 GMT");
+        var dateTime = new DateTime();
+        var timestamp = dateTime.toEpochMilli("Sat, 30 Nov 2019 08:21:14 GMT");
         assertEquals(1575102074000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wed, 02 Oct 2002 13:00:00 GMT");
+        timestamp = dateTime.toEpochMilli("Wed, 02 Oct 2002 13:00:00 GMT");
         assertEquals(1033563600000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 23:25:57 GMT");
+        timestamp = dateTime.toEpochMilli("Wed, 9 Nov 2022 23:25:57 GMT");
         assertEquals(1668036357000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wed, 15 Jan 2020 10:13:32 GMT+6");
+        timestamp = dateTime.toEpochMilli("Wed, 15 Jan 2020 10:13:32 GMT+6");
         assertEquals(1579061612000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wed, 15 Jan 2020 10:13:32 GMT+06:00");
+        timestamp = dateTime.toEpochMilli("Wed, 15 Jan 2020 10:13:32 GMT+06:00");
         assertEquals(1579061612000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Tue, 01 Mar 2022 16:03:00 GMT+0000");
+        timestamp = dateTime.toEpochMilli("Tue, 01 Mar 2022 16:03:00 GMT+0000");
         assertEquals(1646150580000L, timestamp);
     }
 
     @Test
     void dateTimeFormat5() {
-        var timestamp = DateTime.toEpochMilli("2021-11-17T13:21:21Z");
+        var dateTime = new DateTime();
+        var timestamp = dateTime.toEpochMilli("2021-11-17T13:21:21Z");
         assertEquals(1637155281000L, timestamp);
     }
 
     @Test
     void dateTimeFormat6() {
-        var timestamp = DateTime.toEpochMilli("Sun, 04 Sep 2022 09:42:16");
+        var dateTime = new DateTime();
+        var timestamp = dateTime.toEpochMilli("Sun, 04 Sep 2022 09:42:16");
         assertEquals(1662284536000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Sun, 4 Sep 2022 09:42:16");
+        timestamp = dateTime.toEpochMilli("Sun, 4 Sep 2022 09:42:16");
         assertEquals(1662284536000L, timestamp);
     }
 
     @Test
     void dateTimeFormat7() {
         //https://datatracker.ietf.org/doc/html/rfc4287#section-3.3
-        var timestamp = DateTime.toEpochMilli("2003-12-13T18:30:02Z");
+        var dateTime = new DateTime();
+        var timestamp = dateTime.toEpochMilli("2003-12-13T18:30:02Z");
         assertEquals(1071340202000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("2003-12-13T18:30:02.25Z");
+        timestamp = dateTime.toEpochMilli("2003-12-13T18:30:02.25Z");
         assertEquals(1071340202250L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("2003-12-13T18:30:02+01:00");
+        timestamp = dateTime.toEpochMilli("2003-12-13T18:30:02+01:00");
         assertEquals(1071336602000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("2003-12-13T18:30:02.25+01:00");
+        timestamp = dateTime.toEpochMilli("2003-12-13T18:30:02.25+01:00");
         assertEquals(1071336602250L, timestamp);
     }
 
     @Test
     void dateTimeFormat8() {
-        var timestamp = DateTime.toEpochMilli("2022-10-20 02:10:12");
+        var dateTime = new DateTime();
+        var timestamp = dateTime.toEpochMilli("2022-10-20 02:10:12");
         assertEquals(1666231812000L, timestamp);
     }
 
     @Test
     void dateTimeFormat9() {
-        var timestamp = DateTime.toEpochMilli("Fri, 04 Nov 2022 23:00:18 Z");
+        var dateTime = new DateTime();
+        var timestamp = dateTime.toEpochMilli("Fri, 04 Nov 2022 23:00:18 Z");
         assertEquals(1667602818000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Fri, 4 Nov 2022 23:00:18 Z");
+        timestamp = dateTime.toEpochMilli("Fri, 4 Nov 2022 23:00:18 Z");
         assertEquals(1667602818000L, timestamp);
     }
 
     @Test
     void dateTimeFormat10() {
-        var timestamp = DateTime.toEpochMilli("Mon, 07 Nov 2022 06:56:00 UTC");
+        var dateTime = new DateTime();
+        var timestamp = dateTime.toEpochMilli("Mon, 07 Nov 2022 06:56:00 UTC");
         assertEquals(1667804160000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Mon, 7 Nov 2022 06:56:00 UTC");
+        timestamp = dateTime.toEpochMilli("Mon, 7 Nov 2022 06:56:00 UTC");
         assertEquals(1667804160000L, timestamp);
     }
 
     @Test
     void dateTimeFormat11() {
         // Eastern time
-        var timestamp = DateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 EDT");
+        var dateTime = new DateTime();
+        var timestamp = dateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 EDT");
         assertEquals(1667967714000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 EDT");
+        timestamp = dateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 EDT");
         assertEquals(1667967714000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 EST");
+        timestamp = dateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 EST");
         assertEquals(1667971314000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 EST");
+        timestamp = dateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 EST");
         assertEquals(1667971314000L, timestamp);
 
 
         // Central time
-        timestamp = DateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 CDT");
+        timestamp = dateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 CDT");
         assertEquals(1667971314000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 CDT");
+        timestamp = dateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 CDT");
         assertEquals(1667971314000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 CST");
+        timestamp = dateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 CST");
         assertEquals(1667974914000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 CST");
+        timestamp = dateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 CST");
         assertEquals(1667974914000L, timestamp);
 
 
         // Mountain time
-        timestamp = DateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 MDT");
+        timestamp = dateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 MDT");
         assertEquals(1667974914000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 MDT");
+        timestamp = dateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 MDT");
         assertEquals(1667974914000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 MST");
+        timestamp = dateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 MST");
         assertEquals(1667978514000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 MST");
+        timestamp = dateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 MST");
         assertEquals(1667978514000L, timestamp);
 
 
         // Pacific time
-        timestamp = DateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 PDT");
+        timestamp = dateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 PDT");
         assertEquals(1667978514000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 PDT");
+        timestamp = dateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 PDT");
         assertEquals(1667978514000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 PST");
+        timestamp = dateTime.toEpochMilli("Wed, 09 Nov 2022 00:21:54 PST");
         assertEquals(1667982114000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 PST");
+        timestamp = dateTime.toEpochMilli("Wed, 9 Nov 2022 00:21:54 PST");
         assertEquals(1667982114000L, timestamp);
     }
 
     @Test
     void dateTimeFormat12() {
-        assertEquals(1423026000000L, DateTime.toEpochMilli("Wednesday, 04 Feb 2015 00:00:00 EST"));
+        var dateTime = new DateTime();
+        assertEquals(1423026000000L, dateTime.toEpochMilli("Wednesday, 04 Feb 2015 00:00:00 EST"));
         // Eastern time
-        var timestamp = DateTime.toEpochMilli("Wednesday, 09 Nov 2022 00:21:54 EDT");
+        var timestamp = dateTime.toEpochMilli("Wednesday, 09 Nov 2022 00:21:54 EDT");
         assertEquals(1667967714000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wednesday, 9 Nov 2022 00:21:54 EDT");
+        timestamp = dateTime.toEpochMilli("Wednesday, 9 Nov 2022 00:21:54 EDT");
         assertEquals(1667967714000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wednesday, 09 Nov 2022 00:21:54 EST");
+        timestamp = dateTime.toEpochMilli("Wednesday, 09 Nov 2022 00:21:54 EST");
         assertEquals(1667971314000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wednesday, 9 Nov 2022 00:21:54 EST");
+        timestamp = dateTime.toEpochMilli("Wednesday, 9 Nov 2022 00:21:54 EST");
         assertEquals(1667971314000L, timestamp);
 
 
         // Central time
-        timestamp = DateTime.toEpochMilli("Wednesday, 09 Nov 2022 00:21:54 CDT");
+        timestamp = dateTime.toEpochMilli("Wednesday, 09 Nov 2022 00:21:54 CDT");
         assertEquals(1667971314000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wednesday, 9 Nov 2022 00:21:54 CDT");
+        timestamp = dateTime.toEpochMilli("Wednesday, 9 Nov 2022 00:21:54 CDT");
         assertEquals(1667971314000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wednesday, 09 Nov 2022 00:21:54 CST");
+        timestamp = dateTime.toEpochMilli("Wednesday, 09 Nov 2022 00:21:54 CST");
         assertEquals(1667974914000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wednesday, 9 Nov 2022 00:21:54 CST");
+        timestamp = dateTime.toEpochMilli("Wednesday, 9 Nov 2022 00:21:54 CST");
         assertEquals(1667974914000L, timestamp);
 
 
         // Mountain time
-        timestamp = DateTime.toEpochMilli("Wednesday, 09 Nov 2022 00:21:54 MDT");
+        timestamp = dateTime.toEpochMilli("Wednesday, 09 Nov 2022 00:21:54 MDT");
         assertEquals(1667974914000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wednesday, 9 Nov 2022 00:21:54 MDT");
+        timestamp = dateTime.toEpochMilli("Wednesday, 9 Nov 2022 00:21:54 MDT");
         assertEquals(1667974914000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wednesday, 09 Nov 2022 00:21:54 MST");
+        timestamp = dateTime.toEpochMilli("Wednesday, 09 Nov 2022 00:21:54 MST");
         assertEquals(1667978514000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wednesday, 9 Nov 2022 00:21:54 MST");
+        timestamp = dateTime.toEpochMilli("Wednesday, 9 Nov 2022 00:21:54 MST");
         assertEquals(1667978514000L, timestamp);
 
 
         // Pacific time
-        timestamp = DateTime.toEpochMilli("Wednesday, 09 Nov 2022 00:21:54 PDT");
+        timestamp = dateTime.toEpochMilli("Wednesday, 09 Nov 2022 00:21:54 PDT");
         assertEquals(1667978514000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wednesday, 9 Nov 2022 00:21:54 PDT");
+        timestamp = dateTime.toEpochMilli("Wednesday, 9 Nov 2022 00:21:54 PDT");
         assertEquals(1667978514000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wednesday, 09 Nov 2022 00:21:54 PST");
+        timestamp = dateTime.toEpochMilli("Wednesday, 09 Nov 2022 00:21:54 PST");
         assertEquals(1667982114000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wednesday, 9 Nov 2022 00:21:54 PST");
+        timestamp = dateTime.toEpochMilli("Wednesday, 9 Nov 2022 00:21:54 PST");
         assertEquals(1667982114000L, timestamp);
     }
 
     @Test
     void dateTimeFormat13() {
-        var timestamp = DateTime.toEpochMilli("Wed, 02 Oct 2002 13:00:00 CET");
+        var dateTime = new DateTime();
+        var timestamp = dateTime.toEpochMilli("Wed, 02 Oct 2002 13:00:00 CET");
         assertEquals(1033556400000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Wed, 2 Oct 2002 13:00:00 CET");
+        timestamp = dateTime.toEpochMilli("Wed, 2 Oct 2002 13:00:00 CET");
         assertEquals(1033556400000L, timestamp);
     }
 
     @Test
     void dateTimeFormat14() {
-        var timestamp = DateTime.toEpochMilli("Fri, 03 Mar 2023 13:13:53-5:30");
+        var dateTime = new DateTime();
+        var timestamp = dateTime.toEpochMilli("Fri, 03 Mar 2023 13:13:53-5:30");
         assertEquals(1677869033000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Fri, 03 Mar 2023 13:13:53+5:30");
+        timestamp = dateTime.toEpochMilli("Fri, 03 Mar 2023 13:13:53+5:30");
         assertEquals(1677829433000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Fri, 3 Mar 2023 13:13:53-5:30");
+        timestamp = dateTime.toEpochMilli("Fri, 3 Mar 2023 13:13:53-5:30");
         assertEquals(1677869033000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Fri, 3 Mar 2023 13:13:53+5:30");
+        timestamp = dateTime.toEpochMilli("Fri, 3 Mar 2023 13:13:53+5:30");
         assertEquals(1677829433000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Fri, 03 Mar 2023 13:13:53-10:30");
+        timestamp = dateTime.toEpochMilli("Fri, 03 Mar 2023 13:13:53-10:30");
         assertEquals(1677887033000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Fri, 03 Mar 2023 13:13:53+10:30");
+        timestamp = dateTime.toEpochMilli("Fri, 03 Mar 2023 13:13:53+10:30");
         assertEquals(1677811433000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Fri, 3 Mar 2023 13:13:53-10:30");
+        timestamp = dateTime.toEpochMilli("Fri, 3 Mar 2023 13:13:53-10:30");
         assertEquals(1677887033000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Fri, 3 Mar 2023 13:13:53+10:30");
+        timestamp = dateTime.toEpochMilli("Fri, 3 Mar 2023 13:13:53+10:30");
         assertEquals(1677811433000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Fri, 03 Mar 2023 13:13:53-05:30");
+        timestamp = dateTime.toEpochMilli("Fri, 03 Mar 2023 13:13:53-05:30");
         assertEquals(1677869033000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Fri, 03 Mar 2023 13:13:53+05:30");
+        timestamp = dateTime.toEpochMilli("Fri, 03 Mar 2023 13:13:53+05:30");
         assertEquals(1677829433000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Fri, 3 Mar 2023 13:13:53-05:30");
+        timestamp = dateTime.toEpochMilli("Fri, 3 Mar 2023 13:13:53-05:30");
         assertEquals(1677869033000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Fri, 3 Mar 2023 13:13:53+05:30");
+        timestamp = dateTime.toEpochMilli("Fri, 3 Mar 2023 13:13:53+05:30");
         assertEquals(1677829433000L, timestamp);
     }
 
     @Test
     void dateTimeFormat15() {
-        var timestamp = DateTime.toEpochMilli("2023-02-28T17:37:08.823050123+00:00");
+        var dateTime = new DateTime();
+        var timestamp = dateTime.toEpochMilli("2023-02-28T17:37:08.823050123+00:00");
         assertEquals(1677605828823L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("2023-02-28T17:37:08.823050+00:00");
+        timestamp = dateTime.toEpochMilli("2023-02-28T17:37:08.823050+00:00");
         assertEquals(1677605828823L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("2023-02-28T17:37:08.823+00:00");
+        timestamp = dateTime.toEpochMilli("2023-02-28T17:37:08.823+00:00");
         assertEquals(1677605828823L, timestamp);
     }
 
     @Test
     void dateTimeFormat16() {
-        var timestamp = DateTime.toEpochMilli("2023-08-07T10:06:05-0400");
+        var dateTime = new DateTime();
+        var timestamp = dateTime.toEpochMilli("2023-08-07T10:06:05-0400");
         assertEquals(1691417165000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("2023-08-07T10:06:05+0400");
+        timestamp = dateTime.toEpochMilli("2023-08-07T10:06:05+0400");
         assertEquals(1691388365000L, timestamp);
     }
 
     @Test
     void testWrongDayOfWeek() {
-        assertEquals(1423026000000L, DateTime.toEpochMilli("Monday, 04 Feb 2015 00:00:00 EST"));
+        var dateTime = new DateTime();
+        assertEquals(1423026000000L, dateTime.toEpochMilli("Monday, 04 Feb 2015 00:00:00 EST"));
         // Eastern time
-        var timestamp = DateTime.toEpochMilli("Monday, 09 Nov 2022 00:21:54 EDT");
+        var timestamp = dateTime.toEpochMilli("Monday, 09 Nov 2022 00:21:54 EDT");
         assertEquals(1667967714000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Monday, 9 Nov 2022 00:21:54 EDT");
+        timestamp = dateTime.toEpochMilli("Monday, 9 Nov 2022 00:21:54 EDT");
         assertEquals(1667967714000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Monday, 09 Nov 2022 00:21:54 EST");
+        timestamp = dateTime.toEpochMilli("Monday, 09 Nov 2022 00:21:54 EST");
         assertEquals(1667971314000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Monday, 9 Nov 2022 00:21:54 EST");
+        timestamp = dateTime.toEpochMilli("Monday, 9 Nov 2022 00:21:54 EST");
         assertEquals(1667971314000L, timestamp);
 
 
         // Central time
-        timestamp = DateTime.toEpochMilli("Monday, 09 Nov 2022 00:21:54 CDT");
+        timestamp = dateTime.toEpochMilli("Monday, 09 Nov 2022 00:21:54 CDT");
         assertEquals(1667971314000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Monday, 9 Nov 2022 00:21:54 CDT");
+        timestamp = dateTime.toEpochMilli("Monday, 9 Nov 2022 00:21:54 CDT");
         assertEquals(1667971314000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Monday, 09 Nov 2022 00:21:54 CST");
+        timestamp = dateTime.toEpochMilli("Monday, 09 Nov 2022 00:21:54 CST");
         assertEquals(1667974914000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Monday, 9 Nov 2022 00:21:54 CST");
+        timestamp = dateTime.toEpochMilli("Monday, 9 Nov 2022 00:21:54 CST");
         assertEquals(1667974914000L, timestamp);
 
 
         // Mountain time
-        timestamp = DateTime.toEpochMilli("Monday, 09 Nov 2022 00:21:54 MDT");
+        timestamp = dateTime.toEpochMilli("Monday, 09 Nov 2022 00:21:54 MDT");
         assertEquals(1667974914000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Monday, 9 Nov 2022 00:21:54 MDT");
+        timestamp = dateTime.toEpochMilli("Monday, 9 Nov 2022 00:21:54 MDT");
         assertEquals(1667974914000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Monday, 09 Nov 2022 00:21:54 MST");
+        timestamp = dateTime.toEpochMilli("Monday, 09 Nov 2022 00:21:54 MST");
         assertEquals(1667978514000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Monday, 9 Nov 2022 00:21:54 MST");
+        timestamp = dateTime.toEpochMilli("Monday, 9 Nov 2022 00:21:54 MST");
         assertEquals(1667978514000L, timestamp);
 
 
         // Pacific time
-        timestamp = DateTime.toEpochMilli("Monday, 09 Nov 2022 00:21:54 PDT");
+        timestamp = dateTime.toEpochMilli("Monday, 09 Nov 2022 00:21:54 PDT");
         assertEquals(1667978514000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Monday, 9 Nov 2022 00:21:54 PDT");
+        timestamp = dateTime.toEpochMilli("Monday, 9 Nov 2022 00:21:54 PDT");
         assertEquals(1667978514000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Monday, 09 Nov 2022 00:21:54 PST");
+        timestamp = dateTime.toEpochMilli("Monday, 09 Nov 2022 00:21:54 PST");
         assertEquals(1667982114000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Monday, 9 Nov 2022 00:21:54 PST");
+        timestamp = dateTime.toEpochMilli("Monday, 9 Nov 2022 00:21:54 PST");
         assertEquals(1667982114000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("Tue, 23 May 2019 02:00:00 -0700");
+        timestamp = dateTime.toEpochMilli("Tue, 23 May 2019 02:00:00 -0700");
         assertEquals(1558602000000L, timestamp);
     }
 
     @Test
     void dateOnly() {
-        var timestamp = DateTime.toEpochMilli("2023-03-10");
+        var dateTime = new DateTime();
+        var timestamp = dateTime.toEpochMilli("2023-03-10");
         assertEquals(1678406400000L, timestamp);
 
-        timestamp = DateTime.toEpochMilli("20230310");
+        timestamp = dateTime.toEpochMilli("20230310");
         assertEquals(1678406400000L, timestamp);
+    }
+
+    @Test
+    void timestampWithNoTimezone() {
+        var dateTime = new DateTime();
+        var timestamp = dateTime.toEpochMilli("2018-06-01T07:17:52");
+        assertEquals(1527837472000L, timestamp);
+
+        dateTime = new DateTime(ZoneId.of("Australia/Sydney"));
+        timestamp = dateTime.toEpochMilli("2018-06-01T07:17:52");
+        assertEquals(1527801472000L, timestamp);
+
+        dateTime = new DateTime(ZoneId.of("America/Chicago"));
+        timestamp = dateTime.toEpochMilli("2018-06-01T07:17:52");
+        assertEquals(1527855472000L, timestamp);
+
+        dateTime = new DateTime(ZoneId.of("Europe/Paris"));
+        timestamp = dateTime.toEpochMilli("2018-06-01T07:17:52");
+        assertEquals(1527830272000L, timestamp);
     }
 
     @Test
     void badInputNull() {
-        assertNull(DateTime.toLocalDateTime(null));
-        assertNull(DateTime.toZonedDateTime(null));
-        assertNull(DateTime.toEpochMilli(null));
+        var dateTime = new DateTime();
+        assertNull(dateTime.toLocalDateTime(null));
+        assertNull(dateTime.toZonedDateTime(null));
+        assertNull(dateTime.toEpochMilli(null));
     }
 
     @Test
     void badInputZonedDateTime() {
+        var dateTime = new DateTime();
         assertThrows(IllegalArgumentException.class, () ->
-                DateTime.toZonedDateTime("sdflksd"));
+                dateTime.toZonedDateTime("sdflksd"));
     }
-
 
     @Test
     void badInputLocalDateTime() {
+        var dateTime = new DateTime();
         assertThrows(IllegalArgumentException.class, () ->
-                DateTime.toLocalDateTime("sdflksd"));
+                dateTime.toLocalDateTime("sdflksd"));
     }
+
 }


### PR DESCRIPTION
Make it possible to change the default timezone to use if no timezone information exist in the timestamp string. Default UTC is used.

Example pubDate string `2023-08-11T07:17:52` is default treated as a UTC timestamp.

For changing the default timezone to `Australia/Sydney`:
```java
var items = new RssReader().setDateTimeParser(new DateTime("Australia/Sydney"))
                           .read(URL)
                           .collect(Collectors.toList());
```
