### PR TITLE
Author field not mapped for Atom feed

### DIFF
--- a/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
@@ -136,6 +136,7 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
         itemTags.put("content", Item::setDescription);
         itemTags.put("link", Item::setLink);
         itemTags.put("author", Item::setAuthor);
+        itemTags.put("/feed/entry/author/name", Item::setAuthor);
         itemTags.put("category", Item::addCategory);
         itemTags.put("pubDate", Item::setPubDate);
         itemTags.put("published", Item::setPubDate);

--- a/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
+++ b/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
@@ -596,6 +596,14 @@ class RssReaderIntegrationTest {
     }
 
     @Test
+    void testAtomFeed() {
+        var items = new RssReader().read(fromFile("atom-feed.xml"))
+                                   .collect(Collectors.toList());
+        assertEquals(1, items.size());
+        assertEquals("Mark Pilgrim", items.get(0).getAuthor().orElse(null));
+    }
+
+    @Test
     void testReadFromFile() {
         long count = new RssReader().read(fromFile("itunes-podcast.xml")).count();
         assertEquals(9, count);

--- a/src/test/resources/atom-feed.xml
+++ b/src/test/resources/atom-feed.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <title type="text">dive into mark</title>
+    <subtitle type="html">
+        A &lt;em&gt;lot&lt;/em&gt; of effort
+        went into making this effortless
+    </subtitle>
+    <updated>2005-07-31T12:29:29Z</updated>
+    <id>tag:example.org,2003:3</id>
+    <link rel="alternate" type="text/html"
+          hreflang="en" href="http://example.org/"/>
+    <link rel="self" type="application/atom+xml"
+          href="http://example.org/feed.atom"/>
+    <rights>Copyright (c) 2003, Mark Pilgrim</rights>
+    <generator uri="http://www.example.com/" version="1.0">
+        Example Toolkit
+    </generator>
+    <entry>
+        <title>Atom draft-07 snapshot</title>
+        <link rel="alternate" type="text/html"
+              href="http://example.org/2005/04/02/atom"/>
+        <link rel="enclosure" type="audio/mpeg" length="1337"
+              href="http://example.org/audio/ph34r_my_podcast.mp3"/>
+        <id>tag:example.org,2003:3.2397</id>
+        <updated>2005-07-31T12:29:29Z</updated>
+        <published>2003-12-13T08:29:29-04:00</published>
+        <author>
+            <name>Mark Pilgrim</name>
+            <uri>http://example.org/</uri>
+            <email>f8dy@example.com</email>
+        </author>
+        <contributor>
+            <name>Sam Ruby</name>
+        </contributor>
+        <contributor>
+            <name>Joe Gregorio</name>
+        </contributor>
+        <content type="xhtml" xml:lang="en"
+                 xml:base="http://diveintomark.org/">
+            <div xmlns="http://www.w3.org/1999/xhtml">
+                <p><i>[Update: The Atom draft is finished.]</i></p>
+            </div>
+        </content>
+    </entry>
+</feed>


### PR DESCRIPTION
Added missing mapping of Author field for Atom feed. Worked correctly for RSS feed.