### PR TITLE
Content or summary element is not mapped if it contains XML

### DIFF
--- a/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
+++ b/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
@@ -599,8 +599,29 @@ class RssReaderIntegrationTest {
     void testAtomFeed() {
         var items = new RssReader().read(fromFile("atom-feed.xml"))
                                    .collect(Collectors.toList());
-        assertEquals(1, items.size());
-        assertEquals("Mark Pilgrim", items.get(0).getAuthor().orElse(null));
+
+        assertEquals(3, items.size());
+
+        assertEquals("dive into mark", items.get(0).getChannel().getTitle());
+        assertEquals(65, items.get(0).getChannel().getDescription().length());
+        assertEquals("http://example.org/feed.atom", items.get(0).getChannel().getLink());
+        assertEquals("Copyright (c) 2003, Mark Pilgrim", items.get(0).getChannel().getCopyright().orElse(null));
+        assertEquals("Example Toolkit", items.get(0).getChannel().getGenerator().orElse(null));
+        assertEquals("2005-07-31T12:29:29Z", items.get(0).getChannel().getLastBuildDate().orElse(null));
+
+        assertEquals("Atom-Powered Robots Run Amok", items.get(1).getTitle().orElse(null));
+        assertNull(items.get(1).getAuthor().orElse(null));
+        assertEquals("http://example.org/2003/12/13/atom03", items.get(1).getLink().orElse(null));
+        assertEquals("urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a", items.get(1).getGuid().orElse(null));
+        assertEquals("2003-12-13T18:30:02Z", items.get(1).getPubDate().orElse(null));
+        assertEquals(211, items.get(1).getDescription().orElse("").length());
+
+        assertEquals("Atom-Powered Robots Run Amok 2", items.get(2).getTitle().orElse(null));
+        assertNull(items.get(2).getAuthor().orElse(null));
+        assertEquals("http://example.org/2003/12/13/atom04", items.get(2).getLink().orElse(null));
+        assertEquals("urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6b", items.get(2).getGuid().orElse(null));
+        assertEquals("2003-12-13T18:30:01Z", items.get(2).getPubDate().orElse(null));
+        assertEquals(47, items.get(2).getDescription().orElse("").length());
     }
 
     @Test

--- a/src/test/resources/atom-feed.xml
+++ b/src/test/resources/atom-feed.xml
@@ -37,9 +37,32 @@
         </contributor>
         <content type="xhtml" xml:lang="en"
                  xml:base="http://diveintomark.org/">
-            <div xmlns="http://www.w3.org/1999/xhtml">
+            <div xmlns="http://www.w3.org/1999/xhtml" xmlns:t="https://www.apptasticsoftware.com/testing" t:text="some value">
                 <p><i>[Update: The Atom draft is finished.]</i></p>
             </div>
         </content>
+    </entry>
+    <entry>
+        <summary type="text/xml">
+            <p:Customer xmlns:p="http://www.ibm.com/crm"
+                        xmlns="http://www.ibm.com/crm">
+                <id>10</id>
+                <firstName>John</firstName>
+                <lastName>Doe</lastName>
+            </p:Customer>
+        </summary>
+        <title>Atom-Powered Robots Run Amok</title>
+        <link href="http://example.org/2003/12/13/atom03"/>
+        <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
+        <updated>2003-12-13T18:30:02Z</updated>
+    </entry>
+    <entry>
+        <content type="text/json">
+            {"firstName"="John","lastName"="Doe","id"="10"}
+        </content>
+        <title>Atom-Powered Robots Run Amok 2</title>
+        <link href="http://example.org/2003/12/13/atom04"/>
+        <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6b</id>
+        <updated>2003-12-13T18:30:01Z</updated>
     </entry>
 </feed>


### PR DESCRIPTION
For Atom feed if `content` or `summary` element contains XML then it is not mapped to `description` field.

Example:
```xml
<?xml version="1.0" encoding="utf-8"?>
<feed xmlns="http://www.w3.org/2005/Atom">
  <title>Example Feed</title>
  <subtitle>A subtitle.</subtitle>
  <link href="http://example.org/feed/" rel="self"/>
  <link href="http://example.org/"/>
  <updated>2003-12-13T18:30:02Z</updated>
  <author>
    <name>John Doe</name>
    <email>johndoe@example.com</email>
  </author>
  <id>urn:uuid:60a76c80-d399-11d9-b91C-0003939e0af6</id>
  <entry>
    <content type="text/xml">
      <p:Customer xmlns:p="http://www.ibm.com/crm" xmlns="http://www.ibm.com/crm">
        <id>10</id>
      </p:Customer>
    </content>
    <title>Atom-Powered Robots Run Amok</title>
    <link href="http://example.org/2003/12/13/atom03"/>
    <id>urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a</id>
    <updated>2003-12-13T18:30:02Z</updated>
    <summary>Some text.</summary>
  </entry>
</feed>
```