### PR TITLE
Add info about image into rss item.

### DIFF
--- a/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
@@ -220,6 +220,9 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
         enclosureAttributes.putIfAbsent("url", (i, v) -> i.getEnclosure().ifPresent(a -> a.setUrl(v)));
         enclosureAttributes.putIfAbsent("type", (i, v) -> i.getEnclosure().ifPresent(a -> a.setType(v)));
         enclosureAttributes.putIfAbsent("length", (i, v) -> i.getEnclosure().ifPresent(e -> mapLong(v, e::setLength)));
+
+        var mediaThumbnailAttributes = itemAttributes.computeIfAbsent("media:thumbnail", k -> new HashMap<>());
+        mediaThumbnailAttributes.putIfAbsent("url", Item::setImage);
     }
 
     /**

--- a/src/main/java/com/apptasticsoftware/rssreader/Item.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/Item.java
@@ -46,6 +46,7 @@ public class Item implements Comparable<Item> {
     private Boolean isPermaLink;
     private String pubDate;
     private String comments;
+    private String image;
     private Enclosure enclosure;
     private final List<Enclosure> enclosures = new ArrayList<>();
     private Channel channel;
@@ -272,6 +273,22 @@ public class Item implements Comparable<Item> {
      */
     public void setComments(String comments) {
         this.comments = comments;
+    }
+
+    /**
+     * Get image relating to the item.
+     * @return image url
+     */
+    public Optional<String> getImage() {
+        return Optional.ofNullable(image);
+    }
+
+    /**
+     * Set image relating to the item.
+     * @param image image url
+     */
+    public void setImage(String image) {
+        this.image = image;
     }
 
     /**


### PR DESCRIPTION
Hi, @w3stling 

I really appreciate your library since it saved me a lot of time and I really like the extension points with `addItemExtension` API.
However, for my project I needed to parse media:thumbnail attribute of the rss feed. Of course I could parse it into author or comments field as a hack like this `.addItemExtension("media:thumbnail", "url", Item::setAuthor)`, but I would rather contribute to the library to add additional `image` field on the rss `Item` class.

If you don't mind, I've added the default behaviour to abstract parser so it will work out of the box. But if this is inapropriate, I can happily use `.addItemExtension("media:thumbnail", "url", Item::setImage)` in my code.

Let me know if you could accept my PR as is, or should I remove default behaviour from abstact parser and only add an image field on the item class.

I wish you have a best day,
Artem