### PR TITLE
Wrong title and description could be selected

### DIFF
--- a/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
@@ -152,8 +152,9 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
      */
     @SuppressWarnings("java:S1192")
     protected void registerChannelTags() {
-        channelTags.putIfAbsent("title", Channel::setTitle);
-        channelTags.putIfAbsent("description", Channel::setDescription);
+        channelTags.putIfAbsent("/feed/title", Channel::setTitle);
+        channelTags.putIfAbsent("/rss/channel/title", Channel::setTitle);
+        channelTags.putIfAbsent("/rss/channel/description", Channel::setDescription);
         channelTags.putIfAbsent("subtitle", Channel::setDescription);
         channelTags.putIfAbsent("link", Channel::setLink);
         channelTags.putIfAbsent("category", Channel::addCategory);
@@ -191,7 +192,8 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
     protected void registerItemTags() {
         itemTags.putIfAbsent("guid", Item::setGuid);
         itemTags.putIfAbsent("id", Item::setGuid);
-        itemTags.putIfAbsent("title", Item::setTitle);
+        itemTags.putIfAbsent("/feed/entry/title", Item::setTitle);
+        itemTags.putIfAbsent("/rss/channel/item/title", Item::setTitle);
         itemTags.putIfAbsent("description", Item::setDescription);
         itemTags.putIfAbsent("summary", Item::setDescription);
         itemTags.putIfAbsent("content", Item::setDescription);

--- a/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
+++ b/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
@@ -704,6 +704,34 @@ class RssReaderIntegrationTest {
         assertEquals(24, list.size());
     }
 
+    @Test
+    void multipleItemTitleOnDifferentLevels() {
+        var list = new RssReader().read(fromFile("multiple-title-on-different-levels.xml")).collect(Collectors.toList());
+        assertEquals(1, list.size());
+        var item = list.get(0);
+        assertEquals("AC Social", item.getChannel().getTitle());
+        assertEquals("Créer un timelapse d’images satellites", item.getTitle().orElse(""));
+    }
+
+    @Test
+    void multipleChanelTitleOnDifferentLevels() {
+        var list = new RssReader().read(fromFile("multiple-categories.xml")).collect(Collectors.toList());
+        assertEquals(1, list.size());
+        var item = list.get(0);
+        assertEquals("NYT > Top Stories", item.getChannel().getTitle());
+        assertEquals("NYT > Top Stories image title", item.getChannel().getImage().map(Image::getTitle).orElse(""));
+        assertEquals("After Fanning Covid Fears, China Must Now Try to Allay Them", item.getTitle().orElse(""));
+    }
+
+    @Test
+    void multipleChanelDescriptionOnDifferentLevels() {
+        var list = new RssReader().read(fromFile("multiple-categories.xml")).collect(Collectors.toList());
+        assertEquals(1, list.size());
+        var item = list.get(0);
+        assertEquals("NYT > channel description", item.getChannel().getDescription());
+        assertEquals("NYT > image description", item.getChannel().getImage().map(image -> image.getDescription().orElse("")).orElse(""));
+    }
+
     private InputStream fromFile(String fileName) {
         return getClass().getClassLoader().getResourceAsStream(fileName);
     }

--- a/src/test/resources/multiple-categories.xml
+++ b/src/test/resources/multiple-categories.xml
@@ -2,7 +2,7 @@
     <channel>
         <title>NYT > Top Stories</title>
         <link>https://www.nytimes.com</link>
-        <description/>
+        <description>NYT > channel description</description>>
         <language>en-us</language>
         <copyright>Copyright 2022 The New York Times Company</copyright>
         <lastBuildDate>Sat, 03 Dec 2022 11:41:48 +0000</lastBuildDate>
@@ -10,7 +10,8 @@
         <category>News</category>
         <category>China</category>
         <image>
-            <title>NYT > Top Stories</title>
+            <title>NYT > Top Stories image title</title>
+            <description>NYT > image description</description>
             <url>https://static01.nyt.com/images/misc/NYT_logo_rss_250x40.png</url>
             <link>https://www.nytimes.com</link>
         </image>

--- a/src/test/resources/multiple-title-on-different-levels.xml
+++ b/src/test/resources/multiple-title-on-different-levels.xml
@@ -1,0 +1,33 @@
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <title>AC Social</title>
+    <generator uri="http://tt-rss.org/">Tiny Tiny RSS/22.01-4a4928e (Unsupported)</generator>
+    <updated>2022-01-04T14:02:01+00:00</updated>
+    <id>https://reader.lanath.fr/public.php?op=rss&#38;id=-1027&#38;key=sso1m061d4298ba0860</id>
+    <link href="https://reader.lanath.fr/public.php?op=rss&#38;id=-1027&#38;key=sso1m061d4298ba0860" rel="self"/>
+    <link href="https://reader.lanath.fr" rel="alternate"/>
+    <entry>
+        <id>tag:reader.lanath.fr,2022-01-09:/1961725</id>
+        <link href="https://korben.info/timelapse-images-satellites.html" rel="alternate" type="text/html"/>
+        <title type="html">Créer un timelapse d’images satellites</title>
+        <summary type="html">
+            <![CDATA[ <p>Vous vous passionnez pour les images satellites et vous aimeriez bien faire un timelapse d&rsquo;un...</p> ]]>
+        </summary>
+        <content type="html">
+            <![CDATA[ <p><img src="https://korben.info/app/uploads/2021/12/UPTVemppFhNYKNCZUZoDclEEhZ4j8uqN.webp" alt="" loading="lazy" srcset="https://korben.info/app/uploads/2021/12/UPTVemppFhNYKNCZUZoDclEEhZ4j8uqN.webp 600w,https://korben.info/app/uploads/2021/12/UPTVemppFhNYKNCZUZoDclEEhZ4j8uqN-300x200.webp 300w,https://korben.info/app/uploads/2021/12/UPTVemppFhNYKNCZUZoDclEEhZ4j8uqN.webp 600w,https://korben.info/app/uploads/2021/12/UPTVemppFhNYKNCZUZoDclEEhZ4j8uqN-300x200.webp 300w" sizes="(max-width: 600px) 100vw, 600px" referrerpolicy="no-referrer"></p> <p>Vous vous passionnez pour les images satellites et vous aimeriez bien faire un timelapse d&rsquo;une zone particuli&egrave;re de la plan&egrave;te pour montrer son &eacute;volution ?</p> <div><div></div> <div></div></div><p>Et bien avec <a href="https://streamlit.gishub.org/" target="_blank" rel="noopener noreferrer"><strong>Streamlit</strong></a> c&rsquo;est possible. Le principe est simple. Vous s&eacute;lectionnez une zone sur la carte, vous exportez cette zone dans un fichier json. Vous r&eacute;importez ensuite ce json, vous choisissez une collection d&rsquo;images satellites et vous cliquez sur le bouton &laquo;&nbsp;Submit&nbsp;&raquo;.</p> <p>Et voil&agrave;, vous aurez un joli GIF anim&eacute; ou MP4 &agrave; t&eacute;l&eacute;charger. Je vous laisse regarder les vid&eacute;os pour voir ce que &ccedil;a donne.</p> <figure><div> </div></figure><figure><div> </div></figure> ]]>
+        </content>
+        <updated>2022-01-09T08:00:00+00:00</updated>
+        <author>
+            <name>Korben</name>
+        </author>
+        <source>
+            <id>http://korben.info</id>
+            <link rel="self" href="http://korben.info"/>
+            <updated>2022-01-09T08:00:00+00:00</updated>
+            <title>Korben</title>
+        </source>
+        <category term="photos satellites"/>
+        <category term="service web"/>
+        <category term="timelapse"/>
+        <link rel="enclosure" type="" length="1" href="https://korben.info/app/uploads/2021/12/UPTVemppFhNYKNCZUZoDclEEhZ4j8uqN-150x150.webp"/>
+    </entry>
+</feed>


### PR DESCRIPTION
If title or description tag exist on multiple levels the value of the last occurrence will be selected.

For rss feeds description tag can exist in:
`/rss/channel/description` and `/rss/channel/image/description`

For atom feeds title tag can exist in:
`/feed/entry/title` and `/feed/entry/source/title`

Use absolute path to title and description tags instead of relative path with setting up the item and channel mappings.
