### PR TITLE
Add dc mappings

### DIFF
--- a/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
@@ -178,6 +178,9 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
         channelTags.putIfAbsent("/rss/channel/image/description", (C c, String v) -> createIfNullOptional(c::getImage, c::setImage, Image::new).ifPresent(i -> i.setDescription(v)));
         channelTags.putIfAbsent("/rss/channel/image/height", (C c, String v) -> createIfNullOptional(c::getImage, c::setImage, Image::new).ifPresent(i -> mapInteger(v, i::setHeight)));
         channelTags.putIfAbsent("/rss/channel/image/width", (C c, String v) -> createIfNullOptional(c::getImage, c::setImage, Image::new).ifPresent(i -> mapInteger(v, i::setWidth)));
+        channelTags.putIfAbsent("dc:language", (channel, value) -> Mapper.mapIfEmpty(value, channel::getLanguage, channel::setLanguage));
+        channelTags.putIfAbsent("dc:publisher", (channel, value) -> Mapper.mapIfEmpty(value, channel::getCopyright, channel::setCopyright));
+        channelTags.putIfAbsent("dc:title", (channel, value) -> Mapper.mapIfEmpty(value, channel::getTitle, channel::setTitle));
     }
 
     /**
@@ -210,6 +213,8 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
         itemTags.putIfAbsent("comments", Item::setComments);
         itemTags.putIfAbsent("dc:creator", (i, v) -> Mapper.mapIfEmpty(v, i::getAuthor, i::setAuthor));
         itemTags.putIfAbsent("dc:date", (i, v) -> Mapper.mapIfEmpty(v, i::getPubDate, i::setPubDate));
+        itemTags.putIfAbsent("dc:identifier", (i, v) -> Mapper.mapIfEmpty(v, i::getGuid, i::setGuid));
+        itemTags.putIfAbsent("dc:title", (i, v) -> Mapper.mapIfEmpty(v, i::getTitle, i::setTitle));
 
         onItemTags.put("enclosure", i -> i.addEnclosure(new Enclosure()));
     }

--- a/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
@@ -172,12 +172,12 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
         channelTags.putIfAbsent("webMaster", Channel::setWebMaster);
         channelTags.putIfAbsent("docs", Channel::setDocs);
         channelTags.putIfAbsent("rating", Channel::setRating);
-        channelTags.putIfAbsent("/rss/channel/image/link", (C c, String v) -> createIfNull(c::getImage, c::setImage, Image::new).setLink(v));
-        channelTags.putIfAbsent("/rss/channel/image/title", (C c, String v) -> createIfNull(c::getImage, c::setImage, Image::new).setTitle(v));
-        channelTags.putIfAbsent("/rss/channel/image/url", (C c, String v) -> createIfNull(c::getImage, c::setImage, Image::new).setUrl(v));
-        channelTags.putIfAbsent("/rss/channel/image/description", (C c, String v) -> createIfNullOptional(c::getImage, c::setImage, Image::new).ifPresent(i -> i.setDescription(v)));
-        channelTags.putIfAbsent("/rss/channel/image/height", (C c, String v) -> createIfNullOptional(c::getImage, c::setImage, Image::new).ifPresent(i -> mapInteger(v, i::setHeight)));
-        channelTags.putIfAbsent("/rss/channel/image/width", (C c, String v) -> createIfNullOptional(c::getImage, c::setImage, Image::new).ifPresent(i -> mapInteger(v, i::setWidth)));
+        channelTags.putIfAbsent("/rss/channel/image/link", (channel, value) -> createIfNull(channel::getImage, channel::setImage, Image::new).setLink(value));
+        channelTags.putIfAbsent("/rss/channel/image/title", (channel, value) -> createIfNull(channel::getImage, channel::setImage, Image::new).setTitle(value));
+        channelTags.putIfAbsent("/rss/channel/image/url", (channel, value) -> createIfNull(channel::getImage, channel::setImage, Image::new).setUrl(value));
+        channelTags.putIfAbsent("/rss/channel/image/description", (channel, value) -> createIfNullOptional(channel::getImage, channel::setImage, Image::new).ifPresent(i -> i.setDescription(value)));
+        channelTags.putIfAbsent("/rss/channel/image/height", (channel, value) -> createIfNullOptional(channel::getImage, channel::setImage, Image::new).ifPresent(i -> mapInteger(value, i::setHeight)));
+        channelTags.putIfAbsent("/rss/channel/image/width", (channel, value) -> createIfNullOptional(channel::getImage, channel::setImage, Image::new).ifPresent(i -> mapInteger(value, i::setWidth)));
         channelTags.putIfAbsent("dc:language", (channel, value) -> Mapper.mapIfEmpty(value, channel::getLanguage, channel::setLanguage));
         channelTags.putIfAbsent("dc:publisher", (channel, value) -> Mapper.mapIfEmpty(value, channel::getCopyright, channel::setCopyright));
         channelTags.putIfAbsent("dc:title", (channel, value) -> Mapper.mapIfEmpty(value, channel::getTitle, channel::setTitle));
@@ -209,14 +209,14 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
         itemTags.putIfAbsent("category", Item::addCategory);
         itemTags.putIfAbsent("pubDate", Item::setPubDate);
         itemTags.putIfAbsent("published", Item::setPubDate);
-        itemTags.putIfAbsent("updated", (i, v) -> { if (i.getPubDate().isEmpty()) i.setPubDate(v); });
+        itemTags.putIfAbsent("updated", (item, value) -> { if (item.getPubDate().isEmpty()) item.setPubDate(value); });
         itemTags.putIfAbsent("comments", Item::setComments);
-        itemTags.putIfAbsent("dc:creator", (i, v) -> Mapper.mapIfEmpty(v, i::getAuthor, i::setAuthor));
-        itemTags.putIfAbsent("dc:date", (i, v) -> Mapper.mapIfEmpty(v, i::getPubDate, i::setPubDate));
-        itemTags.putIfAbsent("dc:identifier", (i, v) -> Mapper.mapIfEmpty(v, i::getGuid, i::setGuid));
-        itemTags.putIfAbsent("dc:title", (i, v) -> Mapper.mapIfEmpty(v, i::getTitle, i::setTitle));
+        itemTags.putIfAbsent("dc:creator", (item, value) -> Mapper.mapIfEmpty(value, item::getAuthor, item::setAuthor));
+        itemTags.putIfAbsent("dc:date", (item, value) -> Mapper.mapIfEmpty(value, item::getPubDate, item::setPubDate));
+        itemTags.putIfAbsent("dc:identifier", (item, value) -> Mapper.mapIfEmpty(value, item::getGuid, item::setGuid));
+        itemTags.putIfAbsent("dc:title", (item, value) -> Mapper.mapIfEmpty(value, item::getTitle, item::setTitle));
 
-        onItemTags.put("enclosure", i -> i.addEnclosure(new Enclosure()));
+        onItemTags.put("enclosure", item -> item.addEnclosure(new Enclosure()));
     }
 
     /**
@@ -224,12 +224,12 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
      */
     protected void registerItemAttributes() {
         itemAttributes.computeIfAbsent("link", k -> new HashMap<>()).putIfAbsent("href", Item::setLink);
-        itemAttributes.computeIfAbsent("guid", k -> new HashMap<>()).putIfAbsent("isPermaLink", (i, v) -> i.setIsPermaLink(Boolean.parseBoolean(v)) );
+        itemAttributes.computeIfAbsent("guid", k -> new HashMap<>()).putIfAbsent("isPermaLink", (item, value) -> item.setIsPermaLink(Boolean.parseBoolean(value)) );
 
         var enclosureAttributes = itemAttributes.computeIfAbsent("enclosure", k -> new HashMap<>());
-        enclosureAttributes.putIfAbsent("url", (i, v) -> i.getEnclosure().ifPresent(a -> a.setUrl(v)));
-        enclosureAttributes.putIfAbsent("type", (i, v) -> i.getEnclosure().ifPresent(a -> a.setType(v)));
-        enclosureAttributes.putIfAbsent("length", (i, v) -> i.getEnclosure().ifPresent(e -> mapLong(v, e::setLength)));
+        enclosureAttributes.putIfAbsent("url", (item, value) -> item.getEnclosure().ifPresent(a -> a.setUrl(value)));
+        enclosureAttributes.putIfAbsent("type", (item, value) -> item.getEnclosure().ifPresent(a -> a.setType(value)));
+        enclosureAttributes.putIfAbsent("length", (item, value) -> item.getEnclosure().ifPresent(e -> mapLong(value, e::setLength)));
     }
 
     /**

--- a/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
+++ b/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
@@ -739,8 +739,11 @@ class RssReaderIntegrationTest {
         var item = list.get(0);
         assertEquals("tandf: Journal of Web Librarianship: Table of Contents", item.getChannel().getTitle());
         assertEquals("Table of Contents for Journal of Web Librarianship. List of articles from both the latest and ahead of print issues.", item.getChannel().getDescription());
+        assertEquals("en-US", item.getChannel().getLanguage().orElse(""));
+        assertEquals("tandf", item.getChannel().getCopyright().orElse(""));
         assertEquals("I Can’t Get No Satis-Searching: Reassessing Discovery Layers in Academic Libraries Journal of Web Librarianship", item.getTitle().orElse(""));
         assertEquals("Volume 18, Issue 1, January-March 2024, Page 1-14<br/>. <br/>", item.getDescription().orElse(""));
+        assertEquals("doi:10.1080/19322909.2024.2326687", item.getGuid().orElse(""));
     }
 
     private InputStream fromFile(String fileName) {

--- a/src/test/resources/rdf-feed.xml
+++ b/src/test/resources/rdf-feed.xml
@@ -37,7 +37,7 @@
         <link>https://www.tandfonline.com/doi/full/10.1080/19322909.2024.2326687?ai=1dl&amp;mi=el63dh&amp;af=R</link>
         <content:encoded>&lt;a href="/toc/wjwl20/18/1"&gt;Volume 18, Issue 1&lt;/a&gt;, January-March 2024, Page 1-14&lt;br/&gt;. &lt;br/&gt;</content:encoded>
         <description>Volume 18, Issue 1, January-March 2024, Page 1-14&lt;br/&gt;. &lt;br/&gt;</description>
-        <dc:title>I Can’t Get No Satis-Searching: Reassessing Discovery Layers in Academic Libraries Journal of Web Librarianship</dc:title>
+        <dc:title>I Can’t Get No Satis-Searching: Reassessing Discovery Layers in Academic Libraries Journal of Web Librarianship 2</dc:title>
         <dc:identifier>doi:10.1080/19322909.2024.2326687</dc:identifier>
         <dc:source>Journal of Web Librarianship</dc:source>
         <dc:date>2024-04-26T05:36:56Z</dc:date>


### PR DESCRIPTION
Added dc mappings to existing RSS fields (if field is not mapped with a value before):

dc:language -> channel::getLanguage
dc:publisher -> channel::getCopyright
dc:title -> channel::getTitle

dc:identifier -> item::getGuid
dc:title -> item::getTitle