### PR TITLE
Atom category mappings

### DIFF
--- a/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
@@ -189,6 +189,7 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
      */
     protected void registerChannelAttributes() {
         channelAttributes.computeIfAbsent("link", k -> new HashMap<>()).put("href", Channel::setLink);
+        channelAttributes.computeIfAbsent("category", k -> new HashMap<>()).putIfAbsent("term", Channel::addCategory);
     }
 
     /**
@@ -227,6 +228,7 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
     protected void registerItemAttributes() {
         itemAttributes.computeIfAbsent("link", k -> new HashMap<>()).putIfAbsent("href", Item::setLink);
         itemAttributes.computeIfAbsent("guid", k -> new HashMap<>()).putIfAbsent("isPermaLink", (item, value) -> item.setIsPermaLink(Boolean.parseBoolean(value)) );
+        itemAttributes.computeIfAbsent("category", k -> new HashMap<>()).putIfAbsent("term", Item::addCategory);
 
         var enclosureAttributes = itemAttributes.computeIfAbsent("enclosure", k -> new HashMap<>());
         enclosureAttributes.putIfAbsent("url", (item, value) -> item.getEnclosure().ifPresent(a -> a.setUrl(value)));

--- a/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
+++ b/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
@@ -745,6 +745,40 @@ class RssReaderIntegrationTest {
         assertEquals("doi:10.1080/19322909.2024.2326687", item.getGuid().orElse(""));
     }
 
+    @Test
+    void atomFeedWithCategory() {
+        var list = new RssReader().read(fromFile("atom-feed-category.xml"))
+                .collect(Collectors.toList());
+        assertEquals(3, list.size());
+
+        // Item 1
+        assertEquals(3, list.get(0).getChannel().getCategories().size());
+        assertEquals("Programming", list.get(0).getChannel().getCategories().get(0));
+        assertEquals("Computer", list.get(0).getChannel().getCategories().get(1));
+        assertEquals("Developer", list.get(0).getChannel().getCategories().get(2));
+        assertEquals(2, list.get(0).getCategories().size());
+        assertEquals("Microsoft", list.get(0).getCategories().get(0));
+        assertEquals("Azure", list.get(0).getCategories().get(1));
+
+        // Item 2
+        assertEquals(3, list.get(1).getChannel().getCategories().size());
+        assertEquals("Programming", list.get(1).getChannel().getCategories().get(0));
+        assertEquals("Computer", list.get(1).getChannel().getCategories().get(1));
+        assertEquals("Developer", list.get(1).getChannel().getCategories().get(2));
+        assertEquals(1, list.get(1).getCategories().size());
+        assertEquals("Microsoft", list.get(1).getCategories().get(0));
+
+        // Item 3
+        assertEquals(3, list.get(2).getChannel().getCategories().size());
+        assertEquals("Programming", list.get(2).getChannel().getCategories().get(0));
+        assertEquals("Computer", list.get(2).getChannel().getCategories().get(1));
+        assertEquals("Developer", list.get(2).getChannel().getCategories().get(2));
+        assertEquals(3, list.get(2).getCategories().size());
+        assertEquals("Microsoft", list.get(2).getCategories().get(0));
+        assertEquals("API", list.get(2).getCategories().get(1));
+        assertEquals("Azure", list.get(2).getCategories().get(2));
+    }
+
     private InputStream fromFile(String fileName) {
         return getClass().getClassLoader().getResourceAsStream(fileName);
     }

--- a/src/test/resources/atom-feed-category.xml
+++ b/src/test/resources/atom-feed-category.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0" encoding="utf-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <title>FYI Center for Software Developers</title>
+    <subtitle>FYI (For Your Information) Center for Software Developers with
+        large collection of FAQs, tutorials and tips codes for application and
+        wWeb developers on Java, .NET, C, PHP, JavaScript, XML, HTML, CSS, RSS,
+        MySQL and Oracle - dev.fyicenter.com.</subtitle>
+    <link rel="self" href="http://dev.fyicenter.com/atom_xml.php"/>
+    <id>http://dev.fyicenter.com/atom_xml.php</id>
+    <updated>2017-09-22T03:58:52+02:00</updated>
+    <author>
+        <name>FYIcenter.com</name>
+    </author>
+    <rights>Copyright (c) 2017 FYIcenter.com</rights>
+    <category term="Programming"/>
+    <category term="Computer"/>
+    <category term="Developer"/>
+    <entry>
+        <title>Use Developer Portal Internally</title>
+        <link rel="alternate"
+              href="http://dev.fyicenter.com/1000702_Use_Developer_Portal_Internally.ht
+ml"/>
+
+        <id>http://dev.fyicenter.com/1000702_Use_Developer_Portal_Internally.html
+        </id>
+        <updated>2017-09-20T13:29:08+02:00</updated>
+        <summary type="html">&lt;img align='left' width='64' height='64'
+            src='http://dev.fyicenter.com/Azure-API/_icon_Azure-API.png' />How to
+            use the Developer Portal internally by you as the publisher? Normally,
+            the Developer Portal of an Azure API Management Service is used by
+            client developers. But as a publisher, you can also use the Developer
+            Portal to test API operations internally. You can follow this tutorial
+            to access the ...  - Rank: 120; Updated: 2017-09-20 13:29:06 -> &lt;a
+            href='http://dev.fyicenter.com/1000702_Use_Developer_Portal_Internally.ht
+            ml'>Source&lt;/a></summary>
+        <author>
+            <name>FYIcenter.com</name>
+        </author>
+        <category term="Microsoft"/>
+        <category term="Azure"/>
+    </entry>
+    <entry>
+        <title>Using Azure API Management Developer Portal</title>
+        <link rel="alternate"
+              href="http://dev.fyicenter.com/1000701_Using_Azure_API_Management_Develop
+er_Portal.html"/>
+
+        <id>http://dev.fyicenter.com/1000701_Using_Azure_API_Management_Developer
+            _Portal.html</id>
+        <updated>2017-09-20T13:29:07+02:00</updated>
+        <summary type="html">&lt;img align='left' width='64' height='64'
+            src='http://dev.fyicenter.com/Azure-API/_icon_Azure-API.png' />Where to
+            find tutorials on Using Azure API Management Developer Portal? Here is
+            a list of tutorials to answer many frequently asked questions compiled
+            by FYIcenter.com team on Using Azure API Management Developer Portal:
+            Use Developer Portal Internally What Can I See on Developer Portal What
+            I You T...  - Rank: 120; Updated: 2017-09-20 13:29:06 -> &lt;a
+            href='http://dev.fyicenter.com/1000701_Using_Azure_API_Management_Develop
+            er_Portal.html'>Source&lt;/a></summary>
+        <author>
+            <name>FYIcenter.com</name>
+        </author>
+        <category term="Microsoft"/>
+    </entry>
+    <entry>
+        <title>Add API to API Products</title>
+        <link rel="alternate"
+              href="http://dev.fyicenter.com/1000700_Add_API_to_API_Products.html"/>
+        <id>http://dev.fyicenter.com/1000700_Add_API_to_API_Products.html</id>
+        <updated>2017-09-20T13:29:06+02:00</updated>
+        <summary type="html">&lt;img align='left' width='64' height='64'
+            src='http://dev.fyicenter.com/Azure-API/_icon_Azure-API.png' />How to
+            add an API to an API product for internal testing on the Publisher
+            Portal of an Azure API Management Service? You can follow this tutorial
+            to add an API to an API product on the Publisher Portal of an Azure API
+            Management Service. 1. Click API from the left menu on the Publisher
+            Portal. You s...  - Rank: 119; Updated: 2017-09-20 13:29:06 -> &lt;a
+            href='http://dev.fyicenter.com/1000700_Add_API_to_API_Products.html'>Sour
+            ce&lt;/a></summary>
+        <author>
+            <name>FYIcenter.com</name>
+        </author>
+        <category term="Microsoft"/>
+        <category term="API"/>
+        <category term="Azure"/>
+    </entry>
+</feed>


### PR DESCRIPTION
Added category mapping for Atom feed.

/feed/category[term] -> Channel::getCategories)
/feed/entry/category[term] -> Item::getCategories)

```xml
<?xml version="1.0" encoding="utf-8"?>
<feed xmlns="http://www.w3.org/2005/Atom">
    ...
    <category term="Computer"/>
    <category term="Developer"/>
    ...
    <entry>
        ...
        <category term="Microsoft"/>
        <category term="API"/>
        <category term="Azure"/>
        ...
    </entry>
</feed>
```
