### PR TITLE
Add read timeout

### DIFF
--- a/src/test/java/com/apptasticsoftware/integrationtest/ConnectionTest.java
+++ b/src/test/java/com/apptasticsoftware/integrationtest/ConnectionTest.java
@@ -1,0 +1,191 @@
+package com.apptasticsoftware.integrationtest;
+
+import com.apptasticsoftware.rssreader.Item;
+import com.apptasticsoftware.rssreader.RssReader;
+import com.apptasticsoftware.rssreader.util.RssServer;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Duration;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class ConnectionTest {
+    private static final int PORT = 8008;
+
+    @Test
+    void testConnectionTimeoutWithNullValue() {
+        var exception = assertThrows(NullPointerException.class, () -> new RssReader().setConnectionTimeout(null));
+        assertEquals("Connection timeout must not be null", exception.getMessage());
+    }
+
+    @Test
+    void testRequestTimeoutWithNullValue() {
+        var exception = assertThrows(NullPointerException.class, () -> new RssReader().setRequestTimeout(null));
+        assertEquals("Request timeout must not be null", exception.getMessage());
+    }
+
+    @Test
+    void testReadTimeoutWithNullValue() {
+        var exception = assertThrows(NullPointerException.class, () -> new RssReader().setReadTimeout(null));
+        assertEquals("Read timeout must not be null", exception.getMessage());
+    }
+
+    @Test
+    void testConnectionTimeoutWithNegativeValue() {
+        var exception = assertThrows(IllegalArgumentException.class, () -> new RssReader().setConnectionTimeout(Duration.ofSeconds(-30)));
+        assertEquals("Connection timeout must not be negative", exception.getMessage());
+    }
+
+    @Test
+    void testRequestTimeoutWithNegativeValue() {
+        var exception = assertThrows(IllegalArgumentException.class, () -> new RssReader().setRequestTimeout(Duration.ofSeconds(-30)));
+        assertEquals("Request timeout must not be negative", exception.getMessage());
+    }
+
+    @Test
+    void testReadTimeoutWithNegativeValue() {
+        var exception = assertThrows(IllegalArgumentException.class, () -> new RssReader().setReadTimeout(Duration.ofSeconds(-30)));
+        assertEquals("Read timeout must not be negative", exception.getMessage());
+    }
+
+    @Test
+    void testReadFromLocalRssServerNoTimeout() throws IOException {
+        var server = RssServer.with(getFile("atom-feed.xml"))
+                .port(PORT)
+                .endpointPath("/rss")
+                .build();
+        server.start();
+
+        var items = new RssReader()
+                .setConnectionTimeout(Duration.ZERO)
+                .setRequestTimeout(Duration.ZERO)
+                .setReadTimeout(Duration.ZERO)
+                .read("http://localhost:8008/rss")
+                .collect(Collectors.toList());
+
+        server.stop();
+        verify(3, items);
+    }
+
+    @Test
+    void testReadFromLocalRssServer10SecondTimeout() throws IOException {
+        var server = RssServer.with(getFile("atom-feed.xml"))
+                .port(PORT)
+                .endpointPath("/rss")
+                .build();
+        server.start();
+
+        var items = new RssReader()
+                .setConnectionTimeout(Duration.ofSeconds(10))
+                .setRequestTimeout(Duration.ofSeconds(10))
+                .setReadTimeout(Duration.ofSeconds(10))
+                .read("http://localhost:8008/rss")
+                .collect(Collectors.toList());
+
+        server.stop();
+        verify(3, items);
+    }
+
+
+    @Test
+    void testReadFromLocalRssServer() throws IOException {
+        var server = RssServer.with(getFile("atom-feed.xml"))
+                .port(PORT)
+                .endpointPath("/rss")
+                .build();
+        server.start();
+
+        var items = new RssReader()
+                .setReadTimeout(Duration.ofSeconds(2))
+                .read("http://localhost:8008/rss")
+                .collect(Collectors.toList());
+
+        server.stop();
+        verify(3, items);
+    }
+
+    @Test
+    void testNoReadTimeout() throws IOException {
+        var server = RssServer.with(getFile("atom-feed.xml"))
+                .port(PORT)
+                .endpointPath("/rss")
+                .build();
+        server.start();
+
+        var items = new RssReader()
+                .setReadTimeout(Duration.ZERO)
+                .read("http://localhost:8008/rss")
+                .collect(Collectors.toList());
+
+        server.stop();
+        verify(3, items);
+    }
+
+    @Test
+    void testReadTimeout() throws IOException {
+        var server = RssServer.withWritePause(getFile("atom-feed.xml"), Duration.ofSeconds(4))
+                .port(PORT)
+                .endpointPath("/slow-server")
+                .build();
+        server.start();
+
+        var items = new RssReader()
+                .setReadTimeout(Duration.ofSeconds(2))
+                .read("http://localhost:8008/slow-server")
+                .collect(Collectors.toList());
+
+        server.stop();
+        verify(2, items);
+    }
+
+    private static void verify(int expectedSize, List<Item> items) {
+        assertEquals(expectedSize, items.size());
+
+        if (!items.isEmpty()) {
+            assertEquals("dive into mark", items.get(0).getChannel().getTitle());
+            assertEquals(65, items.get(0).getChannel().getDescription().length());
+            assertEquals("http://example.org/feed.atom", items.get(0).getChannel().getLink());
+            assertEquals("Copyright (c) 2003, Mark Pilgrim", items.get(0).getChannel().getCopyright().orElse(null));
+            assertEquals("Example Toolkit", items.get(0).getChannel().getGenerator().orElse(null));
+            assertEquals("2005-07-31T12:29:29Z", items.get(0).getChannel().getLastBuildDate().orElse(null));
+
+            assertEquals("Atom draft-07 snapshot", items.get(0).getTitle().orElse(null));
+            assertNull(items.get(1).getAuthor().orElse(null));
+            assertEquals("http://example.org/audio/ph34r_my_podcast.mp3", items.get(0).getLink().orElse(null));
+            assertEquals("tag:example.org,2003:3.2397", items.get(0).getGuid().orElse(null));
+            assertEquals("2003-12-13T08:29:29-04:00", items.get(0).getPubDate().orElse(null));
+            assertEquals("2005-07-31T12:29:29Z", items.get(0).getUpdated().orElse(null));
+            assertEquals(211, items.get(1).getDescription().orElse("").length());
+        }
+        if (items.size() >= 2) {
+            assertEquals("Atom-Powered Robots Run Amok", items.get(1).getTitle().orElse(null));
+            assertNull(items.get(1).getAuthor().orElse(null));
+            assertEquals("http://example.org/2003/12/13/atom03", items.get(1).getLink().orElse(null));
+            assertEquals("urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6a", items.get(1).getGuid().orElse(null));
+            assertEquals("2003-12-13T18:30:02Z", items.get(1).getPubDate().orElse(null));
+            assertEquals("2003-12-13T18:30:02Z", items.get(1).getUpdated().orElse(null));
+            assertEquals(211, items.get(1).getDescription().orElse("").length());
+        }
+        if (items.size() >= 3) {
+            assertEquals("Atom-Powered Robots Run Amok 2", items.get(2).getTitle().orElse(null));
+            assertNull(items.get(2).getAuthor().orElse(null));
+            assertEquals("http://example.org/2003/12/13/atom04", items.get(2).getLink().orElse(null));
+            assertEquals("urn:uuid:1225c695-cfb8-4ebb-aaaa-80da344efa6b", items.get(2).getGuid().orElse(null));
+            assertEquals("2003-12-13T09:28:28-04:00", items.get(2).getPubDate().orElse(null));
+            assertEquals(1071322108, items.get(2).getPubDateZonedDateTime().map(ZonedDateTime::toEpochSecond).orElse(null));
+            assertEquals("2003-12-13T18:30:01Z", items.get(2).getUpdated().orElse(null));
+            assertEquals(1071340201, items.get(2).getUpdatedZonedDateTime().map(ZonedDateTime::toEpochSecond).orElse(null));
+            assertEquals(47, items.get(2).getDescription().orElse("").length());
+        }
+    }
+
+    private File getFile(String filename) {
+        var url = getClass().getClassLoader().getResource(filename);
+        return new File(url.getFile());
+    }
+}

--- a/src/test/java/com/apptasticsoftware/integrationtest/ConnectionTest.java
+++ b/src/test/java/com/apptasticsoftware/integrationtest/ConnectionTest.java
@@ -14,42 +14,49 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class ConnectionTest {
+class ConnectionTest {
     private static final int PORT = 8008;
+    private static final Duration NEGATIVE_DURATION = Duration.ofSeconds(-30);
 
     @Test
     void testConnectionTimeoutWithNullValue() {
-        var exception = assertThrows(NullPointerException.class, () -> new RssReader().setConnectionTimeout(null));
+        var rssReader = new RssReader();
+        var exception = assertThrows(NullPointerException.class, () -> rssReader.setConnectionTimeout(null));
         assertEquals("Connection timeout must not be null", exception.getMessage());
     }
 
     @Test
     void testRequestTimeoutWithNullValue() {
-        var exception = assertThrows(NullPointerException.class, () -> new RssReader().setRequestTimeout(null));
+        var rssReader = new RssReader();
+        var exception = assertThrows(NullPointerException.class, () -> rssReader.setRequestTimeout(null));
         assertEquals("Request timeout must not be null", exception.getMessage());
     }
 
     @Test
     void testReadTimeoutWithNullValue() {
-        var exception = assertThrows(NullPointerException.class, () -> new RssReader().setReadTimeout(null));
+        var rssReader = new RssReader();
+        var exception = assertThrows(NullPointerException.class, () -> rssReader.setReadTimeout(null));
         assertEquals("Read timeout must not be null", exception.getMessage());
     }
 
     @Test
     void testConnectionTimeoutWithNegativeValue() {
-        var exception = assertThrows(IllegalArgumentException.class, () -> new RssReader().setConnectionTimeout(Duration.ofSeconds(-30)));
+        var rssReader = new RssReader();
+        var exception = assertThrows(IllegalArgumentException.class, () -> rssReader.setConnectionTimeout(NEGATIVE_DURATION));
         assertEquals("Connection timeout must not be negative", exception.getMessage());
     }
 
     @Test
     void testRequestTimeoutWithNegativeValue() {
-        var exception = assertThrows(IllegalArgumentException.class, () -> new RssReader().setRequestTimeout(Duration.ofSeconds(-30)));
+        var rssReader = new RssReader();
+        var exception = assertThrows(IllegalArgumentException.class, () -> rssReader.setRequestTimeout(NEGATIVE_DURATION));
         assertEquals("Request timeout must not be negative", exception.getMessage());
     }
 
     @Test
     void testReadTimeoutWithNegativeValue() {
-        var exception = assertThrows(IllegalArgumentException.class, () -> new RssReader().setReadTimeout(Duration.ofSeconds(-30)));
+        var rssReader = new RssReader();
+        var exception = assertThrows(IllegalArgumentException.class, () -> rssReader.setReadTimeout(NEGATIVE_DURATION));
         assertEquals("Read timeout must not be negative", exception.getMessage());
     }
 

--- a/src/test/java/com/apptasticsoftware/rssreader/util/RssServer.java
+++ b/src/test/java/com/apptasticsoftware/rssreader/util/RssServer.java
@@ -1,0 +1,176 @@
+package com.apptasticsoftware.rssreader.util;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+
+import java.io.*;
+import java.net.InetSocketAddress;
+import java.nio.file.Files;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+/**
+ * Basic RSS server from testing
+ */
+public class RssServer {
+    private static final Logger LOGGER = Logger.getLogger("RssServer");
+    private final HttpServer server;
+
+    private RssServer(int port, String endpointPath, File file, Duration writeBodyPause) throws IOException {
+        server = HttpServer.create(new InetSocketAddress(port), 0);
+        server.createContext(endpointPath, new FileRssHandler(file, writeBodyPause));
+        server.setExecutor(null);
+    }
+
+    /**
+     * RSS server that publish the given file content as an RSS/Atom feed.
+     * @param file content to publish
+     * @return RSS server
+     */
+    public static RssServerBuilder with(File file) {
+        Objects.requireNonNull(file, "File must not be null");
+        if (!file.isFile()) {
+            throw new IllegalArgumentException("File must exist");
+        }
+        return new RssServerBuilder(file, Duration.ZERO);
+    }
+
+    /**
+     * RSS server that publish the given file content as an RSS/Atom feed.
+     * Server will publish 90% of the data and then wait the given amount of time before publish the rest of the data.
+     * @param file content to publish
+     * @param writeBodyPause time to wait before publishing the last data
+     * @return RSS server
+     */
+    public static RssServerBuilder withWritePause(File file, Duration writeBodyPause) {
+        Objects.requireNonNull(file, "File must not be null");
+        if (!file.isFile()) {
+            throw new IllegalArgumentException("File must exist");
+        }
+        Objects.requireNonNull(writeBodyPause, "Write body pause must not be null");
+        if (writeBodyPause.isNegative()) {
+            throw new IllegalArgumentException("Write body pause must not be negative");
+        }
+        return new RssServerBuilder(file, writeBodyPause);
+    }
+
+    /**
+     * Start RSS server
+     */
+    public void start() {
+        server.start();
+    }
+
+    /**
+     * Stop RSS server
+     */
+    public void stop() {
+        server.stop(1);
+    }
+
+    private static class FileRssHandler implements HttpHandler {
+        private final File file;
+        private final Duration writeBodyPause;
+
+        public FileRssHandler(File file, Duration writeBodyPause) {
+            this.file = file;
+            this.writeBodyPause = writeBodyPause;
+        }
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            LOGGER.info("New connection " + Instant.now());
+            var responseBodyLength = Files.size(file.toPath());
+            exchange.sendResponseHeaders(200, responseBodyLength);
+
+            try (var os = exchange.getResponseBody()) {
+                writeResponseBody(os, responseBodyLength);
+            }
+
+            LOGGER.info("Connection closed " + Instant.now());
+        }
+
+        private void writeResponseBody(OutputStream os, long responseBodyLength) throws IOException {
+            byte[] buffer = new byte[128];
+            int readLength;
+            int totalReadLength = 0;
+            boolean hasPaused = false;
+
+            try (var is = new FileInputStream(file)){
+                while ((readLength = is.read(buffer)) != -1) {
+                    totalReadLength += readLength;
+                    os.write(buffer, 0, readLength);
+                    if (isWritePause(totalReadLength, responseBodyLength) && !hasPaused) {
+                        pause(writeBodyPause);
+                        hasPaused = true;
+                        LOGGER.info("Continue to write " + Instant.now());
+                    }
+                }
+            }
+
+            os.flush();
+        }
+
+        private boolean isWritePause(int length, long totalLength) {
+            return writeBodyPause.toMillis() > 0 && length >= totalLength * 0.90;
+        }
+
+        private void pause(Duration duration) {
+            try {
+                TimeUnit.MILLISECONDS.sleep(duration.toMillis());
+            } catch (InterruptedException ignore) {
+                Thread.currentThread().interrupt();
+            }
+        }
+
+    }
+
+    /**
+     * Builder for RSS server
+     */
+    public static class RssServerBuilder {
+        private int port = 8080;
+        private String endpointPath = "/rss";
+        private final File file;
+        private final Duration writeBodyPause;
+
+        RssServerBuilder(File file, Duration writeBodyPause) {
+            this.file = file;
+            this.writeBodyPause = writeBodyPause;
+        }
+
+        /**
+         * Port number to use. Default: 8080
+         * @param port port number
+         * @return builder
+         */
+        public RssServerBuilder port(int port) {
+            this.port = port;
+            return this;
+        }
+
+        /**
+         * The endpoint path to use. Default: /rss
+         * @param endpointPath endpoint path
+         * @return builder
+         */
+        public RssServerBuilder endpointPath(String endpointPath) {
+            this.endpointPath = endpointPath;
+            return this;
+        }
+
+        /**
+         * Builds and configures the RSS server
+         * @return RSS server
+         * @throws IOException if an I/O error occurs
+         */
+        public RssServer build() throws IOException {
+            return new RssServer(port, endpointPath, file, writeBodyPause);
+        }
+    }
+
+}

--- a/src/test/java/com/apptasticsoftware/rssreader/util/RssServer.java
+++ b/src/test/java/com/apptasticsoftware/rssreader/util/RssServer.java
@@ -119,6 +119,7 @@ public class RssServer {
             return writeBodyPause.toMillis() > 0 && length >= totalLength * 0.90;
         }
 
+        @SuppressWarnings("java:S2925")
         private void pause(Duration duration) {
             try {
                 TimeUnit.MILLISECONDS.sleep(duration.toMillis());


### PR DESCRIPTION
Added timeout for reading the response body. Default value for read timeout is 25 seconds.

Also exposed methods for setting connection timeout and request timeout. The default value for these timeouts are 25 seconds same as in previous releases.

Example for changing timeout:
```java
var timeout = Duration.ofSeconds(10);

var items = new RssReader()
        .setConnectionTimeout(timeout)
        .setRequestTimeout(timeout)
        .setReadTimeout(timeout)
        .read("https://lwn.net/headlines/rss")
        .collect(Collectors.toList());
```

This PR fixes issue #163 