### PR TITLE
Close underlying resources when no timeout is used

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,8 +43,8 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v3
+    #- name: Autobuild
+    #  uses: github/codeql-action/autobuild@v3
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -53,9 +53,7 @@ jobs:
     #    and modify them (or add more) to build your code if your project
     #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+    - run: ./gradlew clean build -x test
 
     - name: Perform CodeQL analysis
       uses: github/codeql-action/analyze@v3

--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,6 @@ compileJava {
     inputs.property('moduleName', moduleName)
     doFirst {
         options.compilerArgs = [
-                '-Xlint:unchecked',
                 '--module-path', classpath.asPath
         ]
         classpath = files()

--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,10 @@ compileJava {
     }
 }
 
+compileTestJava {
+    options.compilerArgs = [ '-Xlint:unchecked' ]
+}
+
 jacoco {
     toolVersion = "0.8.9"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -44,14 +44,11 @@ compileJava {
     inputs.property('moduleName', moduleName)
     doFirst {
         options.compilerArgs = [
+                '-Xlint:unchecked',
                 '--module-path', classpath.asPath
         ]
         classpath = files()
     }
-}
-
-compileTestJava {
-    options.compilerArgs = [ '-Xlint:unchecked' ]
 }
 
 jacoco {

--- a/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
@@ -570,14 +570,18 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
         @Override
         public void run() {
             try {
-                xmlStreamReader.close();
+                if (xmlStreamReader != null) {
+                    xmlStreamReader.close();
+                }
             } catch (XMLStreamException e) {
                 LOGGER.log(Level.WARNING, "Failed to close XML stream. ", e);
             }
 
             for (AutoCloseable resource : resources) {
                 try {
-                    resource.close();
+                    if (resource != null) {
+                        resource.close();
+                    }
                 } catch (Exception e) {
                     LOGGER.log(Level.WARNING, "Failed to close resource. ", e);
                 }
@@ -625,10 +629,10 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
 
         public void close() {
             if (isClosed.compareAndSet(false, true)) {
-                Optional.ofNullable(cleanable).ifPresent(Cleaner.Cleanable::clean);
-                cleanable = null;
-                Optional.ofNullable(parseWatchdog).ifPresent(sf -> sf.cancel(false));
-                parseWatchdog = null;
+                cleanable.clean();
+                if (parseWatchdog != null) {
+                    parseWatchdog.cancel(false);
+                }
             }
         }
 

--- a/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
@@ -36,6 +36,7 @@ import javax.xml.stream.XMLStreamReader;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.lang.ref.Cleaner;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
@@ -69,6 +70,7 @@ import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
 public abstract class AbstractRssReader<C extends Channel, I extends Item> {
     private static final Logger LOGGER = Logger.getLogger("com.apptasticsoftware.rssreader");
     private static final ScheduledExecutorService EXECUTOR = new ScheduledThreadPoolExecutor(1, new DaemonThreadFactory("RssReaderWorker"));
+    private static final Cleaner CLEANER = Cleaner.create();
     private final HttpClient httpClient;
     private DateTimeParser dateTimeParser = new DateTime();
     private String userAgent = "";
@@ -556,10 +558,36 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
         } catch (IOException ignore) { }
     }
 
-    class RssItemIterator implements Iterator<I> {
+    private static class CleaningAction implements Runnable {
+        private final XMLStreamReader xmlStreamReader;
+        private final List<AutoCloseable> resources;
+
+        public CleaningAction(XMLStreamReader xmlStreamReader, AutoCloseable... resources) {
+            this.xmlStreamReader = xmlStreamReader;
+            this.resources = List.of(resources);
+        }
+
+        @Override
+        public void run() {
+            try {
+                xmlStreamReader.close();
+            } catch (XMLStreamException e) {
+                LOGGER.log(Level.WARNING, "Failed to close XML stream. ", e);
+            }
+
+            for (AutoCloseable resource : resources) {
+                try {
+                    resource.close();
+                } catch (Exception e) {
+                    LOGGER.log(Level.WARNING, "Failed to close resource. ", e);
+                }
+            }
+        }
+    }
+
+    class RssItemIterator implements Iterator<I>, AutoCloseable {
         private final StringBuilder textBuilder;
         private final Map<String, StringBuilder> childNodeTextBuilder;
-        private final InputStream is;
         private final Deque<String> elementStack;
         private XMLStreamReader reader;
         private C channel;
@@ -569,9 +597,9 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
         private boolean isItemPart = false;
         private ScheduledFuture<?> parseWatchdog;
         private final AtomicBoolean isClosed;
+        private Cleaner.Cleanable cleanable;
 
         public RssItemIterator(InputStream is) {
-            this.is = is;
             nextItem = null;
             textBuilder = new StringBuilder();
             childNodeTextBuilder = new HashMap<>();
@@ -585,6 +613,7 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
                 xmlInputFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, false);
 
                 reader = xmlInputFactory.createXMLStreamReader(is);
+                cleanable = CLEANER.register(this, new CleaningAction(reader, is));
                 if (!readTimeout.isZero()) {
                     parseWatchdog = EXECUTOR.schedule(this::close, readTimeout.toMillis(), TimeUnit.MILLISECONDS);
                 }
@@ -595,16 +624,11 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
         }
 
         public void close() {
-            if (isClosed.compareAndSet(false,true)) {
-                try {
-                    if (parseWatchdog != null) {
-                        parseWatchdog.cancel(false);
-                    }
-                    reader.close();
-                    is.close();
-                } catch (XMLStreamException | IOException e) {
-                    LOGGER.log(Level.WARNING, "Failed to close XML stream. ", e);
-                }
+            if (isClosed.compareAndSet(false, true)) {
+                Optional.ofNullable(cleanable).ifPresent(Cleaner.Cleanable::clean);
+                cleanable = null;
+                Optional.ofNullable(parseWatchdog).ifPresent(sf -> sf.cancel(false));
+                parseWatchdog = null;
             }
         }
 

--- a/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
+++ b/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
@@ -608,6 +608,7 @@ class RssReaderIntegrationTest {
         }
     }
 
+    @SuppressWarnings("java:S2925")
     @Test
     void testCloseWithCleaner() {
         var fileInputSteam = fromFile("atom-feed.xml");
@@ -625,11 +626,11 @@ class RssReaderIntegrationTest {
             System.gc();
             try {
                 Thread.sleep(10L);
-            } catch (InterruptedException ignore) { }
+            } catch (InterruptedException ignored) { /* ignore */ }
         }
 
         IOException thrown = assertThrows(IOException.class, fileInputSteam::available);
-        assertEquals(thrown.getMessage(), "Stream closed");
+        assertEquals("Stream closed", thrown.getMessage());
     }
 
     @SuppressWarnings("java:S5961")

--- a/src/test/java/com/apptasticsoftware/rssreader/RssReaderTest.java
+++ b/src/test/java/com/apptasticsoftware/rssreader/RssReaderTest.java
@@ -47,7 +47,7 @@ class RssReaderTest {
                 "</channel>\n" +
                 "</rss>\n";
 
-        CompletableFuture<HttpResponse<InputStream>> httpResponse = createMock(response);
+        var httpResponse = createMock(response);
         RssReader readerMock = Mockito.spy(RssReader.class);
         doReturn(httpResponse).when(readerMock).sendAsyncRequest(anyString());
 
@@ -78,7 +78,7 @@ class RssReaderTest {
                 "</channel>\n" +
                 "</rss>\n";
 
-        CompletableFuture<HttpResponse<InputStream>> httpResponse = createMock(response);
+        var httpResponse = createMock(response);
         RssReader readerMock = Mockito.spy(RssReader.class);
         doReturn(httpResponse).when(readerMock).sendAsyncRequest(anyString());
 
@@ -125,7 +125,7 @@ class RssReaderTest {
                 "</channel>\n" +
                 "</rss>\n";
 
-        CompletableFuture<HttpResponse<InputStream>> httpResponse = createMock(response);
+        var httpResponse = createMock(response);
         RssReader readerMock = Mockito.spy(RssReader.class);
         doReturn(httpResponse).when(readerMock).sendAsyncRequest(anyString());
 
@@ -172,7 +172,7 @@ class RssReaderTest {
                 "</channel>\n" +
                 "</rss>\n";
 
-        CompletableFuture<HttpResponse<InputStream>> httpResponse = createMock(response);
+        var httpResponse = createMock(response);
         RssReader readerMock = Mockito.spy(RssReader.class);
         doReturn(httpResponse).when(readerMock).sendAsyncRequest(anyString());
 
@@ -219,7 +219,7 @@ class RssReaderTest {
                 "</channel>\n" +
                 "</rss>\n";
 
-        CompletableFuture<HttpResponse<InputStream>> httpResponse = createMock(response);
+        var httpResponse = createMock(response);
         RssReader readerMock = Mockito.spy(RssReader.class);
         doReturn(httpResponse).when(readerMock).sendAsyncRequest(anyString());
 
@@ -248,7 +248,7 @@ class RssReaderTest {
     void emptyResponse() throws IOException {
         String response = "";
 
-        CompletableFuture<HttpResponse<InputStream>> httpResponse = createMock(response);
+        var httpResponse = createMock(response);
         RssReader readerMock = Mockito.spy(RssReader.class);
         doReturn(httpResponse).when(readerMock).sendAsyncRequest(anyString());
 
@@ -514,9 +514,8 @@ class RssReaderTest {
     }
 
 
-    private CompletableFuture<HttpResponse<InputStream>> createMock(String response) {
-        HttpResponse<InputStream> httpResponse = mock(HttpResponse.class);
-
+    private CompletableFuture createMock(String response) {
+        var httpResponse = mock(HttpResponse.class);
         InputStream responseStream = new ByteArrayInputStream(response.getBytes());
         doReturn(responseStream).when(httpResponse).body();
 


### PR DESCRIPTION
### **User description**
This PR fixes a special case where the underlying resource was not closed when using zero read timeout and reading the feed using an iterator or a spliterator.

Example:
```java
var stream = new RssReader().setReadTimeout(Duration.ZERO).read(URL);
var iterator = stream.iterator();
var item = iterator.next();
```


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Implemented a `Cleaner` in `AbstractRssReader` to ensure underlying resources are properly closed when no timeout is used.
- Added a new `CleaningAction` class to handle the closing of `XMLStreamReader` and other resources.
- Modified `RssItemIterator` to implement `AutoCloseable` and utilize `Cleaner` for resource management.
- Enhanced the integration tests to include a test case for verifying resource cleanup using `Cleaner`.
- Updated existing tests to use try-with-resources for better resource management.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AbstractRssReader.java</strong><dd><code>Implement resource cleanup using Cleaner in AbstractRssReader</code></dd></summary>
<hr>

src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java

<li>Introduced a <code>Cleaner</code> to manage resource cleanup.<br> <li> Added <code>CleaningAction</code> class to handle resource closing.<br> <li> Modified <code>RssItemIterator</code> to implement <code>AutoCloseable</code>.<br> <li> Updated resource management logic to ensure proper closure.<br>


</details>


  </td>
  <td><a href="https://github.com/w3stling/rssreader/pull/178/files#diff-5a097d88f39fdbd552c3310d7b5e1c547981bb185595f89a39dfa2d43982502c">+37/-13</a>&nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RssReaderIntegrationTest.java</strong><dd><code>Add tests for resource cleanup and modify existing tests</code>&nbsp; </dd></summary>
<hr>

src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java

<li>Added a test to verify resource cleanup using <code>Cleaner</code>.<br> <li> Modified existing test to use try-with-resources for <code>HttpClient</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/w3stling/rssreader/pull/178/files#diff-e3f6b1853376dd1aad7d112ef1288e16898598dc64e5b1eec698d2e591844968">+30/-3</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

