### PR TITLE
Support for reading from file URI

### DIFF
--- a/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
+++ b/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
@@ -821,7 +821,39 @@ class RssReaderIntegrationTest {
         assertEquals("Azure", list.get(2).getCategories().get(2));
     }
 
+    @Test
+    void readFromFileUri() throws IOException, URISyntaxException {
+        var uri = getFileUri("rss-feed.xml");
+        var items = new RssReader().read(uri).collect(Collectors.toList());
+        assertEquals(20, items.size());
+    }
+
+    @Test
+    void readFromMultipleFileUri() throws URISyntaxException {
+        var uris = List.of(
+                getFileUri("rss-feed.xml"),
+                getFileUri("atom-feed.xml")
+        );
+        var items = new RssReader().read(uris).collect(Collectors.toList());
+        assertEquals(23, items.size());
+    }
+
+    @Test
+    void readFromAMixOfUrlAndFileUri() throws URISyntaxException {
+        var sources = List.of(
+                getFileUri("rss-feed.xml"),
+                "https://www.nasa.gov/news-release/feed/",
+                getFileUri("atom-feed.xml")
+        );
+        var items = new RssReader().read(sources).collect(Collectors.toList());
+        assertEquals(33, items.size());
+    }
+
     private InputStream fromFile(String fileName) {
         return getClass().getClassLoader().getResourceAsStream(fileName);
+    }
+
+    private String getFileUri(String fileName) throws URISyntaxException {
+        return getClass().getClassLoader().getResource(fileName).toURI().toString();
     }
 }

--- a/src/test/java/com/apptasticsoftware/integrationtest/SortTest.java
+++ b/src/test/java/com/apptasticsoftware/integrationtest/SortTest.java
@@ -6,7 +6,6 @@ import com.apptasticsoftware.rssreader.util.ItemComparator;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -46,10 +45,7 @@ class SortTest {
                 "https://feeds.arstechnica.com/arstechnica/science"
         );
 
-        List<String> extendedUrlList = new ArrayList<>(urlList);
-        extendedUrlList.add(null);
-
-        var timestamps = new RssReader().read(extendedUrlList)
+        var timestamps = new RssReader().read(urlList)
                 .sorted()
                 .map(Item::getPubDateZonedDateTime)
                 .flatMap(Optional::stream)


### PR DESCRIPTION
Added support for reading from file URI.

Example reading from a single file:
```java
List<Item> items = new RssReader().read("file:/path/to/file").toList()
```


Example reading from a mix of files and URLs:
```java
List<String> sources = List.of(
   "file:/path/to/file",
   "https://www.nasa.gov/news-release/feed/",
   "file:///path/to/another/file",
   "https://www.engadget.com/rss.xml"));

List<Item> items = new RssReader().read(sources).toList()
```