### PR TITLE
Unhandled timestamp format

### DIFF
--- a/src/main/java/com/apptasticsoftware/rssreader/DateTime.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/DateTime.java
@@ -99,6 +99,8 @@ public class DateTime implements DateTimeParser {
     private static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_PST_NO_DOW;
     private static final DateTimeFormatter RFC_1123_DATE_TIME_SPECIAL_PDT_NO_DOW;
 
+    private static final DateTimeFormatter DATE_TIME_SPECIAL_1;
+
     static {
         BASIC_ISO_DATE = DateTimeFormatter.BASIC_ISO_DATE.withLocale(Locale.ENGLISH);
         ISO_LOCAL_DATE = DateTimeFormatter.ISO_LOCAL_DATE.withLocale(Locale.ENGLISH);
@@ -160,6 +162,8 @@ public class DateTime implements DateTimeParser {
         RFC_1123_DATE_TIME_SPECIAL_MST_NO_DOW = DateTimeFormatter.ofPattern("d LLL yyyy H:m:s 'MST'", Locale.ENGLISH).withZone(ZoneOffset.ofHours(-7));
         RFC_1123_DATE_TIME_SPECIAL_PDT_NO_DOW = DateTimeFormatter.ofPattern("d LLL yyyy H:m:s 'PDT'", Locale.ENGLISH).withZone(ZoneOffset.ofHours(-7));
         RFC_1123_DATE_TIME_SPECIAL_PST_NO_DOW = DateTimeFormatter.ofPattern("d LLL yyyy H:m:s 'PST'", Locale.ENGLISH).withZone(ZoneOffset.ofHours(-8));
+
+        DATE_TIME_SPECIAL_1 = DateTimeFormatter.ofPattern("d MMM yyyy HH:mm:ss Z", Locale.ENGLISH);
     }
 
     /**
@@ -254,6 +258,10 @@ public class DateTime implements DateTimeParser {
         int index = dateTime.indexOf(',');
 
         if (index == -1) {
+            index = dateTime.indexOf(' ');
+            if (Character.isDigit(dateTime.charAt(0)) && (index == 1 || index == 2)) {
+                return DATE_TIME_SPECIAL_1;
+            }
             return parseIsoDateTime(dateTime);
         } else if (index <= 3) {
             return parseRfcDateTime(dateTime);

--- a/src/test/java/com/apptasticsoftware/rssreader/DateTimeTest.java
+++ b/src/test/java/com/apptasticsoftware/rssreader/DateTimeTest.java
@@ -359,6 +359,16 @@ class DateTimeTest {
     }
 
     @Test
+    void dateTimeFormat17() {
+        var dateTime = new DateTime();
+        var timestamp = dateTime.toEpochMilli("1 Dec 2024 09:15:08 +0000");
+        assertEquals(1733044508000L, timestamp);
+
+        timestamp = dateTime.toEpochMilli("01 Dec 2024 09:15:08 +0000");
+        assertEquals(1733044508000L, timestamp);
+    }
+
+    @Test
     void testWrongDayOfWeek() {
         var dateTime = new DateTime();
         assertEquals(1423026000000L, dateTime.toEpochMilli("Monday, 04 Feb 2015 00:00:00 EST"));


### PR DESCRIPTION
Unhandled timestamp format:
`1 Dec 2024 09:15:08 +0000`

This bug affects code that calls `sorted()` or calls getters that return `ZonedDateTime`