### PR TITLE
Comparators for sorting items by updated time

### DIFF
--- a/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
@@ -25,6 +25,7 @@ package com.apptasticsoftware.rssreader;
 
 import com.apptasticsoftware.rssreader.internal.StreamUtil;
 import com.apptasticsoftware.rssreader.internal.stream.AutoCloseStream;
+import com.apptasticsoftware.rssreader.util.Default;
 import com.apptasticsoftware.rssreader.util.Mapper;
 import com.apptasticsoftware.rssreader.internal.DaemonThreadFactory;
 import com.apptasticsoftware.rssreader.internal.XMLInputFactorySecurity;
@@ -71,7 +72,7 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
     private static final ScheduledExecutorService EXECUTOR = new ScheduledThreadPoolExecutor(1, new DaemonThreadFactory("RssReaderWorker"));
     private static final Cleaner CLEANER = Cleaner.create();
     private final HttpClient httpClient;
-    private DateTimeParser dateTimeParser = new DateTime();
+    private DateTimeParser dateTimeParser = Default.getDateTimeParser();
     private String userAgent = "";
     private Duration connectionTimeout = Duration.ofSeconds(25);
     private Duration requestTimeout = Duration.ofSeconds(25);

--- a/src/main/java/com/apptasticsoftware/rssreader/Item.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/Item.java
@@ -63,7 +63,7 @@ public class Item implements Comparable<Item> {
     @Deprecated(since="3.5.0", forRemoval=true)
     public Item() {
         dateTimeParser = Default.getDateTimeParser();
-        defaultComparator = ItemComparator.newestItemFirst();
+        defaultComparator = ItemComparator.newestPublishedItemFirst();
     }
 
     /**
@@ -72,7 +72,7 @@ public class Item implements Comparable<Item> {
      */
     public Item(DateTimeParser dateTimeParser) {
         this.dateTimeParser = dateTimeParser;
-        defaultComparator = ItemComparator.newestItemFirst(dateTimeParser);
+        defaultComparator = ItemComparator.newestPublishedItemFirst(dateTimeParser);
     }
 
     /**

--- a/src/main/java/com/apptasticsoftware/rssreader/util/ItemComparator.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/util/ItemComparator.java
@@ -33,7 +33,9 @@ import java.util.Objects;
 /**
  * Provides different comparators for sorting item objects.
  */
+@SuppressWarnings("java:S1133")
 public final class ItemComparator {
+    private static final String MUST_NOT_BE_NULL_MESSAGE = "Date time parser must not be null";
 
     private ItemComparator() {
 
@@ -43,6 +45,8 @@ public final class ItemComparator {
      * Comparator for sorting Items on initial creation or first availability (publication date) in ascending order (oldest first)
      * @param <I> any class that extends Item
      * @return comparator
+     *
+     * @deprecated As of release 3.9.0, replaced by {@link #oldestPublishedItemFirst()}
      */
     @Deprecated(since = "3.9.0", forRemoval = true)
     public static <I extends Item> Comparator<I> oldestItemFirst() {
@@ -76,6 +80,8 @@ public final class ItemComparator {
      * @param <I> any class that extends Item
      * @param dateTimeParser date time parser
      * @return comparator
+     *
+     * @deprecated As of release 3.9.0, replaced by {@link #oldestPublishedItemFirst(DateTimeParser)}
      */
     @Deprecated(since = "3.9.0", forRemoval = true)
     public static <I extends Item> Comparator<I> oldestItemFirst(DateTimeParser dateTimeParser) {
@@ -89,7 +95,7 @@ public final class ItemComparator {
      * @return comparator
      */
     public static <I extends Item> Comparator<I> oldestPublishedItemFirst(DateTimeParser dateTimeParser) {
-        Objects.requireNonNull(dateTimeParser, "Date time parser must not be null");
+        Objects.requireNonNull(dateTimeParser, MUST_NOT_BE_NULL_MESSAGE);
         return Comparator.comparing((I i) ->
                         i.getPubDate().map(dateTimeParser::parse).orElse(null),
                 Comparator.nullsLast(Comparator.naturalOrder()));
@@ -102,7 +108,7 @@ public final class ItemComparator {
      * @return comparator
      */
     public static <I extends Item> Comparator<I> oldestUpdatedItemFirst(DateTimeParser dateTimeParser) {
-        Objects.requireNonNull(dateTimeParser, "Date time parser must not be null");
+        Objects.requireNonNull(dateTimeParser, MUST_NOT_BE_NULL_MESSAGE);
         return Comparator.comparing((I i) ->
                         i.getUpdated().or(i::getPubDate).map(dateTimeParser::parse).orElse(null),
                 Comparator.nullsLast(Comparator.naturalOrder()));
@@ -112,6 +118,8 @@ public final class ItemComparator {
      * Comparator for sorting Items on initial creation or first availability (publication date) in descending order (newest first)
      * @param <I> any class that extends Item
      * @return comparator
+     *
+     * @deprecated As of release 3.9.0, replaced by {@link #newestPublishedItemFirst()}
      */
     @Deprecated(since = "3.9.0", forRemoval = true)
     public static <I extends Item> Comparator<I> newestItemFirst() {
@@ -145,6 +153,8 @@ public final class ItemComparator {
      * @param <I> any class that extends Item
      * @param dateTimeParser date time parser
      * @return comparator
+     *
+     * @deprecated As of release 3.9.0, replaced by {@link #newestPublishedItemFirst(DateTimeParser)}
      */
     @Deprecated(since = "3.9.0", forRemoval = true)
     public static <I extends Item> Comparator<I> newestItemFirst(DateTimeParser dateTimeParser) {
@@ -158,7 +168,7 @@ public final class ItemComparator {
      * @return comparator
      */
     public static <I extends Item> Comparator<I> newestPublishedItemFirst(DateTimeParser dateTimeParser) {
-        Objects.requireNonNull(dateTimeParser, "Date time parser must not be null");
+        Objects.requireNonNull(dateTimeParser, MUST_NOT_BE_NULL_MESSAGE);
         return Comparator.comparing((I i) ->
                         i.getPubDate().map(dateTimeParser::parse).orElse(null),
                 Comparator.nullsLast(Comparator.naturalOrder())).reversed();
@@ -171,7 +181,7 @@ public final class ItemComparator {
      * @return comparator
      */
     public static <I extends Item> Comparator<I> newestUpdatedItemFirst(DateTimeParser dateTimeParser) {
-        Objects.requireNonNull(dateTimeParser, "Date time parser must not be null");
+        Objects.requireNonNull(dateTimeParser, MUST_NOT_BE_NULL_MESSAGE);
         return Comparator.comparing((I i) ->
                         i.getUpdated().or(i::getPubDate).map(dateTimeParser::parse).orElse(null),
                 Comparator.nullsLast(Comparator.naturalOrder())).reversed();

--- a/src/main/java/com/apptasticsoftware/rssreader/util/ItemComparator.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/util/ItemComparator.java
@@ -23,11 +23,10 @@
  */
 package com.apptasticsoftware.rssreader.util;
 
+import com.apptasticsoftware.rssreader.Channel;
 import com.apptasticsoftware.rssreader.DateTimeParser;
 import com.apptasticsoftware.rssreader.Item;
 
-import java.time.Instant;
-import java.time.ZonedDateTime;
 import java.util.Comparator;
 import java.util.Objects;
 
@@ -41,54 +40,153 @@ public final class ItemComparator {
     }
 
     /**
-     * Comparator for sorting Items on publication date in ascending order (oldest first)
-     * @param <I> any class that extend Item
+     * Comparator for sorting Items on initial creation or first availability (publication date) in ascending order (oldest first)
+     * @param <I> any class that extends Item
      * @return comparator
      */
+    @Deprecated(since = "3.9.0", forRemoval = true)
     public static <I extends Item> Comparator<I> oldestItemFirst() {
-        var dateTime = Default.getDateTimeParser();
-        return Comparator.comparing((I i) -> i.getPubDate().map(dateTime::toInstant).orElse(Instant.EPOCH));
+        return oldestPublishedItemFirst();
     }
 
     /**
-     * Comparator for sorting Items on publication date in ascending order (oldest first)
-     * @param <I> any class that extend Item
+     * Comparator for sorting Items on initial creation or first availability (publication date) in ascending order (oldest first)
+     * @param <I> any class that extends Item
+     * @return comparator
+     */
+    public static <I extends Item> Comparator<I> oldestPublishedItemFirst() {
+        return Comparator.comparing((I i) ->
+                        i.getPubDateZonedDateTime().orElse(null),
+                Comparator.nullsLast(Comparator.naturalOrder()));
+    }
+
+    /**
+     * Comparator for sorting Items on updated date if exist otherwise on publication date in ascending order (oldest first)
+     * @param <I> any class that extends Item
+     * @return comparator
+     */
+    public static <I extends Item> Comparator<I> oldestUpdatedItemFirst() {
+        return Comparator.comparing((I i) ->
+                        i.getUpdatedZonedDateTime().orElse(i.getPubDateZonedDateTime().orElse(null)),
+                Comparator.nullsLast(Comparator.naturalOrder()));
+    }
+
+    /**
+     * Comparator for sorting Items on initial creation or first availability (publication date) in ascending order (oldest first)
+     * @param <I> any class that extends Item
      * @param dateTimeParser date time parser
      * @return comparator
      */
+    @Deprecated(since = "3.9.0", forRemoval = true)
     public static <I extends Item> Comparator<I> oldestItemFirst(DateTimeParser dateTimeParser) {
-        Objects.requireNonNull(dateTimeParser, "Date time parser must not be null");
-        return Comparator.comparing((I i) -> i.getPubDate().map(dateTimeParser::parse).map(ZonedDateTime::toInstant).orElse(Instant.EPOCH));
+        return oldestPublishedItemFirst(dateTimeParser);
     }
 
     /**
-     * Comparator for sorting Items on publication date in descending order (newest first)
-     * @param <I> any class that extend Item
-     * @return comparator
-     */
-    public static <I extends Item> Comparator<I> newestItemFirst() {
-        var dateTime = Default.getDateTimeParser();
-        return Comparator.comparing((I i) -> i.getPubDate().map(dateTime::toInstant).orElse(Instant.EPOCH)).reversed();
-    }
-
-    /**
-     * Comparator for sorting Items on publication date in descending order (newest first)
-     * @param <I> any class that extend Item
+     * Comparator for sorting Items on initial creation or first availability (publication date) in ascending order (oldest first)
+     * @param <I> any class that extends Item
      * @param dateTimeParser date time parser
      * @return comparator
      */
-    public static <I extends Item> Comparator<I> newestItemFirst(DateTimeParser dateTimeParser) {
+    public static <I extends Item> Comparator<I> oldestPublishedItemFirst(DateTimeParser dateTimeParser) {
         Objects.requireNonNull(dateTimeParser, "Date time parser must not be null");
-        return Comparator.comparing((I i) -> i.getPubDate().map(dateTimeParser::parse).map(ZonedDateTime::toInstant).orElse(Instant.EPOCH)).reversed();
+        return Comparator.comparing((I i) ->
+                        i.getPubDate().map(dateTimeParser::parse).orElse(null),
+                Comparator.nullsLast(Comparator.naturalOrder()));
+    }
+
+    /**
+     * Comparator for sorting Items on updated date if exist otherwise on publication date in ascending order (oldest first)
+     * @param <I> any class that extends Item
+     * @param dateTimeParser date time parser
+     * @return comparator
+     */
+    public static <I extends Item> Comparator<I> oldestUpdatedItemFirst(DateTimeParser dateTimeParser) {
+        Objects.requireNonNull(dateTimeParser, "Date time parser must not be null");
+        return Comparator.comparing((I i) ->
+                        i.getUpdated().or(i::getPubDate).map(dateTimeParser::parse).orElse(null),
+                Comparator.nullsLast(Comparator.naturalOrder()));
+    }
+
+    /**
+     * Comparator for sorting Items on initial creation or first availability (publication date) in descending order (newest first)
+     * @param <I> any class that extends Item
+     * @return comparator
+     */
+    @Deprecated(since = "3.9.0", forRemoval = true)
+    public static <I extends Item> Comparator<I> newestItemFirst() {
+        return newestPublishedItemFirst();
+    }
+
+    /**
+     * Comparator for sorting Items on initial creation or first availability (publication date) in descending order (newest first)
+     * @param <I> any class that extends Item
+     * @return comparator
+     */
+    public static <I extends Item> Comparator<I> newestPublishedItemFirst() {
+        return Comparator.comparing((I i) ->
+                        i.getPubDateZonedDateTime().orElse(null),
+                Comparator.nullsLast(Comparator.naturalOrder())).reversed();
+    }
+
+    /**
+     * Comparator for sorting Items on updated date if exist otherwise on publication date in descending order (newest first)
+     * @param <I> any class that extends Item
+     * @return comparator
+     */
+    public static <I extends Item> Comparator<I> newestUpdatedItemFirst() {
+        return Comparator.comparing((I i) ->
+                        i.getUpdatedZonedDateTime().orElse(i.getPubDateZonedDateTime().orElse(null)),
+                Comparator.nullsLast(Comparator.naturalOrder())).reversed();
+    }
+
+    /**
+     * Comparator for sorting Items on initial creation or first availability (publication date) in descending order (newest first)
+     * @param <I> any class that extends Item
+     * @param dateTimeParser date time parser
+     * @return comparator
+     */
+    @Deprecated(since = "3.9.0", forRemoval = true)
+    public static <I extends Item> Comparator<I> newestItemFirst(DateTimeParser dateTimeParser) {
+        return newestPublishedItemFirst(dateTimeParser);
+    }
+
+    /**
+     * Comparator for sorting Items on initial creation or first availability (publication date) in descending order (newest first)
+     * @param <I> any class that extends Item
+     * @param dateTimeParser date time parser
+     * @return comparator
+     */
+    public static <I extends Item> Comparator<I> newestPublishedItemFirst(DateTimeParser dateTimeParser) {
+        Objects.requireNonNull(dateTimeParser, "Date time parser must not be null");
+        return Comparator.comparing((I i) ->
+                        i.getPubDate().map(dateTimeParser::parse).orElse(null),
+                Comparator.nullsLast(Comparator.naturalOrder())).reversed();
+    }
+
+    /**
+     * Comparator for sorting Items on updated date if exist otherwise on publication date in descending order (newest first)
+     * @param <I> any class that extends Item
+     * @param dateTimeParser date time parser
+     * @return comparator
+     */
+    public static <I extends Item> Comparator<I> newestUpdatedItemFirst(DateTimeParser dateTimeParser) {
+        Objects.requireNonNull(dateTimeParser, "Date time parser must not be null");
+        return Comparator.comparing((I i) ->
+                        i.getUpdated().or(i::getPubDate).map(dateTimeParser::parse).orElse(null),
+                Comparator.nullsLast(Comparator.naturalOrder())).reversed();
     }
 
     /**
      * Comparator for sorting Items on channel title
-     * @param <I> any class that extend Item
+     * @param <I> any class that extends Item
      * @return comparator
      */
     public static <I extends Item> Comparator<I> channelTitle() {
-        return Comparator.comparing((I i) -> i.getChannel().getTitle());
+        return Comparator.comparing(
+                Item::getChannel,
+                Comparator.nullsFirst(Comparator.comparing(
+                        Channel::getTitle, Comparator.nullsFirst(Comparator.naturalOrder()))));
     }
 
 }

--- a/src/test/java/com/apptasticsoftware/rssreader/util/ItemComparatorTest.java
+++ b/src/test/java/com/apptasticsoftware/rssreader/util/ItemComparatorTest.java
@@ -1,6 +1,5 @@
 package com.apptasticsoftware.rssreader.util;
 
-import com.apptasticsoftware.rssreader.DateTime;
 import com.apptasticsoftware.rssreader.RssReader;
 import org.junit.jupiter.api.Test;
 
@@ -27,8 +26,20 @@ class ItemComparatorTest {
     }
 
     @Test
+    void testSortNewestPublishedItem() throws IOException {
+        var items = new RssReader().read("https://www.theverge.com/rss/reviews/index.xml")
+                .sorted(ItemComparator.newestPublishedItemFirst())
+                .map(i -> i.getPubDateZonedDateTime().orElse(null))
+                .filter(Objects::nonNull)
+                .map(ZonedDateTime::toEpochSecond)
+                .collect(Collectors.toList());
+
+        assertTrue(isDescendingSortOrder(items));
+    }
+
+    @Test
     void testSortNewestItemWithCustomDateTimeParser() throws IOException {
-        var items = new RssReader().setDateTimeParser(new DateTime())
+        var items = new RssReader().setDateTimeParser(Default.getDateTimeParser())
                                    .read("https://www.theverge.com/rss/reviews/index.xml")
                                    .sorted(ItemComparator.newestItemFirst())
                                    .map(i -> i.getPubDateZonedDateTime().orElse(null))
@@ -40,13 +51,38 @@ class ItemComparatorTest {
     }
 
     @Test
+    void testSortNewestPublishedItemWithCustomDateTimeParser() throws IOException {
+        var items = new RssReader().setDateTimeParser(Default.getDateTimeParser())
+                .read("https://www.theverge.com/rss/reviews/index.xml")
+                .sorted(ItemComparator.newestPublishedItemFirst())
+                .map(i -> i.getPubDateZonedDateTime().orElse(null))
+                .filter(Objects::nonNull)
+                .map(ZonedDateTime::toEpochSecond)
+                .collect(Collectors.toList());
+
+        assertTrue(isDescendingSortOrder(items));
+    }
+
+    @Test
     void testSortNewestItemWithDateTimeParser() throws IOException {
         var items = new RssReader().read("https://www.theverge.com/rss/reviews/index.xml")
-                                   .sorted(ItemComparator.newestItemFirst(new DateTime()))
+                                   .sorted(ItemComparator.newestItemFirst(Default.getDateTimeParser()))
                                    .map(i -> i.getPubDateZonedDateTime().orElse(null))
                                    .filter(Objects::nonNull)
                                    .map(ZonedDateTime::toEpochSecond)
                                    .collect(Collectors.toList());
+
+        assertTrue(isDescendingSortOrder(items));
+    }
+
+    @Test
+    void testSortNewestPublishedItemWithDateTimeParser() throws IOException {
+        var items = new RssReader().read("https://www.theverge.com/rss/reviews/index.xml")
+                .sorted(ItemComparator.newestPublishedItemFirst(Default.getDateTimeParser()))
+                .map(i -> i.getPubDateZonedDateTime().orElse(null))
+                .filter(Objects::nonNull)
+                .map(ZonedDateTime::toEpochSecond)
+                .collect(Collectors.toList());
 
         assertTrue(isDescendingSortOrder(items));
     }
@@ -63,12 +99,93 @@ class ItemComparatorTest {
     }
 
     @Test
+    void testSortOldestPublishedItemFirst() throws IOException {
+        var items = new RssReader().read("https://www.theverge.com/rss/reviews/index.xml")
+                .sorted(ItemComparator.oldestPublishedItemFirst())
+                .map(i -> i.getPubDateZonedDateTime().orElse(null))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        assertTrue(isAscendingSortOrder(items));
+    }
+
+    @Test
     void testSortOldestItemFirstWithDateTimeParser() throws IOException {
         var items = new RssReader().read("https://www.theverge.com/rss/reviews/index.xml")
-                                   .sorted(ItemComparator.oldestItemFirst(new DateTime()))
+                                   .sorted(ItemComparator.oldestItemFirst(Default.getDateTimeParser()))
                                    .map(i -> i.getPubDateZonedDateTime().orElse(null))
                                    .filter(Objects::nonNull)
                                    .collect(Collectors.toList());
+
+        assertTrue(isAscendingSortOrder(items));
+    }
+
+    @Test
+    void testSortOldestPublishedItemFirstWithDateTimeParser() throws IOException {
+        var items = new RssReader().read("https://www.theverge.com/rss/reviews/index.xml")
+                .sorted(ItemComparator.oldestPublishedItemFirst(Default.getDateTimeParser()))
+                .map(i -> i.getPubDateZonedDateTime().orElse(null))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        assertTrue(isAscendingSortOrder(items));
+    }
+
+    @Test
+    void testSortNewestUpdatedItem() throws IOException {
+        var items = new RssReader().read("https://www.theverge.com/rss/reviews/index.xml")
+                .sorted(ItemComparator.newestUpdatedItemFirst())
+                .map(i -> i.getUpdatedZonedDateTime().orElse(null))
+                .filter(Objects::nonNull)
+                .map(ZonedDateTime::toEpochSecond)
+                .collect(Collectors.toList());
+
+        assertTrue(isDescendingSortOrder(items));
+    }
+
+    @Test
+    void testSortNewestUpdatedItemWithCustomDateTimeParser() throws IOException {
+        var items = new RssReader().setDateTimeParser(Default.getDateTimeParser())
+                .read("https://www.theverge.com/rss/reviews/index.xml")
+                .sorted(ItemComparator.newestUpdatedItemFirst())
+                .map(i -> i.getUpdatedZonedDateTime().orElse(null))
+                .filter(Objects::nonNull)
+                .map(ZonedDateTime::toEpochSecond)
+                .collect(Collectors.toList());
+
+        assertTrue(isDescendingSortOrder(items));
+    }
+
+    @Test
+    void testSortNewestUpdatedItemWithDateTimeParser() throws IOException {
+        var items = new RssReader().read("https://www.theverge.com/rss/reviews/index.xml")
+                .sorted(ItemComparator.newestUpdatedItemFirst(Default.getDateTimeParser()))
+                .map(i -> i.getUpdatedZonedDateTime().orElse(null))
+                .filter(Objects::nonNull)
+                .map(ZonedDateTime::toEpochSecond)
+                .collect(Collectors.toList());
+
+        assertTrue(isDescendingSortOrder(items));
+    }
+
+    @Test
+    void testSortOldestUpdatedItemFirst() throws IOException {
+        var items = new RssReader().read("https://www.theverge.com/rss/reviews/index.xml")
+                .sorted(ItemComparator.oldestUpdatedItemFirst())
+                .map(i -> i.getUpdatedZonedDateTime().orElse(null))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+
+        assertTrue(isAscendingSortOrder(items));
+    }
+
+    @Test
+    void testSortOldestUpdatedItemFirstWithDateTimeParser() throws IOException {
+        var items = new RssReader().read("https://www.theverge.com/rss/reviews/index.xml")
+                .sorted(ItemComparator.oldestUpdatedItemFirst(Default.getDateTimeParser()))
+                .map(i -> i.getUpdatedZonedDateTime().orElse(null))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
 
         assertTrue(isAscendingSortOrder(items));
     }

--- a/src/test/java/com/apptasticsoftware/rssreader/util/ItemComparatorTest.java
+++ b/src/test/java/com/apptasticsoftware/rssreader/util/ItemComparatorTest.java
@@ -11,6 +11,7 @@ import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@SuppressWarnings("java:S5738")
 class ItemComparatorTest {
 
     @Test


### PR DESCRIPTION
Added comparators for sorting items by updated time.
 * `ItemComparator::oldestUpdatedItemFirst`
 * `ItemComparator::newestUpdatedItemFirst`
 
 Renamed comparators for sorting by published time.
 * `ItemComparator::oldestItemFirst` -> `ItemComparator::oldestPublishedItemFirst`
 * `ItemComparator::newestItemFirst `-> `ItemComparator::newestPublishedItemFirst`

Deprecated old method names and marked them for removal in future versions.