### PR TITLE
Improve log message

### DIFF
--- a/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
@@ -655,7 +655,7 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
                 }
             }
             catch (XMLStreamException e) {
-                LOGGER.log(Level.WARNING, String.format("Failed to process XML from source %s", source), e);
+                LOGGER.log(Level.WARNING, String.format("Failed to process XML from feed %s", source), e);
             }
         }
 
@@ -711,7 +711,7 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
                     }
                 }
             } catch (XMLStreamException e) {
-                LOGGER.log(Level.WARNING, String.format("Failed to parse XML from source %s", source), e);
+                LOGGER.log(Level.WARNING, String.format("Failed to parse XML from feed %s", source), e);
             }
 
             close();

--- a/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
@@ -479,7 +479,10 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
      */
     public Stream<I> read(InputStream inputStream) {
         Objects.requireNonNull(inputStream, "Input stream must not be null");
+        return read("", inputStream);
+    }
 
+    protected Stream<I> read(String source, InputStream inputStream) {
         if (!isInitialized) {
             initialize();
             isInitialized = true;
@@ -487,7 +490,7 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
 
         inputStream = new BufferedInputStream(inputStream);
         removeBadData(inputStream);
-        var itemIterator = new RssItemIterator(inputStream);
+        var itemIterator = new RssItemIterator(source, inputStream);
         return AutoCloseStream.of(StreamUtil.asStream(itemIterator).onClose(itemIterator::close));
     }
 
@@ -510,7 +513,7 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
                 // Read from file
                 return CompletableFuture.supplyAsync(() -> {
                     try {
-                        return read(new FileInputStream(uri.getPath()));
+                        return read(uri.getPath(), new FileInputStream(uri.getPath()));
                     } catch (FileNotFoundException e) {
                         throw new CompletionException(e);
                     }
@@ -523,7 +526,7 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
             return CompletableFuture.supplyAsync(() -> {
                 // Read feed data provided as a string
                 var inputStream = new ByteArrayInputStream(url.getBytes(StandardCharsets.UTF_8));
-                return read(inputStream);
+                return read("", inputStream);
             });
         }
     }
@@ -562,7 +565,7 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
 
                 inputStream = new BufferedInputStream(inputStream);
                 removeBadData(inputStream);
-                var itemIterator = new RssItemIterator(inputStream);
+                var itemIterator = new RssItemIterator(response.uri().toString(), inputStream);
                 return AutoCloseStream.of(StreamUtil.asStream(itemIterator).onClose(itemIterator::close));
             } catch (IOException e) {
                 throw new CompletionException(e);
@@ -620,6 +623,7 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
         private final StringBuilder textBuilder;
         private final Map<String, StringBuilder> childNodeTextBuilder;
         private final Deque<String> elementStack;
+        private final String source;
         private XMLStreamReader reader;
         private C channel;
         private I item = null;
@@ -630,12 +634,13 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
         private final AtomicBoolean isClosed;
         private Cleaner.Cleanable cleanable;
 
-        public RssItemIterator(InputStream is) {
+        public RssItemIterator(String source, InputStream is) {
             nextItem = null;
             textBuilder = new StringBuilder();
             childNodeTextBuilder = new HashMap<>();
             elementStack = new ArrayDeque<>();
             isClosed = new AtomicBoolean(false);
+            this.source = source;
 
             try {
                 // disable XML external entity (XXE) processing
@@ -650,7 +655,7 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
                 }
             }
             catch (XMLStreamException e) {
-                LOGGER.log(Level.WARNING, "Failed to process XML.", e);
+                LOGGER.log(Level.WARNING, String.format("Failed to process XML from source %s", source), e);
             }
         }
 
@@ -706,7 +711,7 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
                     }
                 }
             } catch (XMLStreamException e) {
-                LOGGER.log(Level.WARNING, "Failed to parse XML.", e);
+                LOGGER.log(Level.WARNING, String.format("Failed to parse XML from source %s", source), e);
             }
 
             close();

--- a/src/test/java/com/apptasticsoftware/rssreader/RssReaderTest.java
+++ b/src/test/java/com/apptasticsoftware/rssreader/RssReaderTest.java
@@ -7,6 +7,7 @@ import org.mockito.Mockito;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.net.http.HttpHeaders;
 import java.net.http.HttpResponse;
 import java.util.HashMap;
@@ -527,8 +528,9 @@ class RssReaderTest {
     }
 
 
-    private CompletableFuture createMock(String response) {
+    private CompletableFuture<?> createMock(String response) {
         var httpResponse = mock(HttpResponse.class);
+        doReturn(URI.create("https://www.site.com/feed")).when(httpResponse).uri();
         InputStream responseStream = new ByteArrayInputStream(response.getBytes());
         doReturn(responseStream).when(httpResponse).body();
 


### PR DESCRIPTION
Improve log message by including the feed URL / file path when an exception is caught.

Example log message:
```java
WARNING: Failed to parse XML from feed https://capitallinkshipping.com/login/?redirect_to=https%3A%2F%2Fcapitallinkshipping.com%2Ffeed%2F
javax.xml.stream.XMLStreamException: ParseError at [row,col]:[1,3]
Message: The markup in the document preceding the root element must be well-formed.
	at java.xml/com.sun.org.apache.xerces.internal.impl.XMLStreamReaderImpl.next(XMLStreamReaderImpl.java:652)
	at com.apptasticsoftware.rssreader.AbstractRssReader$RssItemIterator.next(AbstractRssReader.java:698)
	at com.apptasticsoftware.rssreader.AbstractRssReader$RssItemIterator.peekNext(AbstractRssReader.java:674)
	at com.apptasticsoftware.rssreader.AbstractRssReader$RssItemIterator.hasNext(AbstractRssReader.java:683)
	at java.base/java.util.Iterator.forEachRemaining(Iterator.java:132)
...
```
