### PR TITLE
Add jar manifest attributes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,12 +3,13 @@ plugins {
     id 'jacoco'
     id 'signing'
     id 'maven-publish'
+    id 'biz.aQute.bnd.builder' version '7.1.0'
     id 'io.github.gradle-nexus.publish-plugin' version '2.0.0'
     id 'org.sonarqube' version '6.1.0.5360'
 }
 
-group 'com.apptasticsoftware'
-version "${version}"
+group = 'com.apptasticsoftware'
+version = "${version}"
 
 repositories {
     mavenCentral()
@@ -57,6 +58,24 @@ jacoco {
 jacocoTestReport {
     reports {
         xml.required = true
+    }
+}
+
+jar {
+    manifest {
+        attributes(
+                "Build-Jdk-Spec": java.targetCompatibility,
+                "Implementation-Title": "RSS Reader",
+                "Implementation-Version": version,
+                "Specification-Title": "RSS Reader",
+                "Specification-Version": version.replace("-SNAPSHOT", ""),
+                "Automatic-Module-Name": moduleName,
+                "Bundle-SymbolicName": moduleName,
+                "Bundle-Description": "Java library for reading RSS and Atom feeds",
+                "Bundle-License": "https://opensource.org/licenses/MIT",
+                "Bundle-Name": "RSS Reader",
+                "Export-Package": "*;-split-package:=merge-first;-noimport:=true",
+        )
     }
 }
 


### PR DESCRIPTION
This PR fixes issue #218

Added the following attributes to MANIFEST.MD file.
```
Manifest-Version: 1.0
Automatic-Module-Name: com.apptasticsoftware.rssreader
Bnd-LastModified: 1745170840738
Build-Jdk-Spec: 11
Bundle-Description: Java library for reading RSS and Atom feeds
Bundle-License: https://opensource.org/licenses/MIT
Bundle-ManifestVersion: 2
Bundle-Name: RSS Reader
Bundle-SymbolicName: com.apptasticsoftware.rssreader
Bundle-Version: 3.9.3
Created-By: 21.0.1 (Eclipse Adoptium)
Export-Package: com.apptasticsoftware.rssreader;version="3.9.3",com.ap
 ptasticsoftware.rssreader.internal;uses:="javax.xml.stream";version="
 3.9.3",com.apptasticsoftware.rssreader.internal.stream;version="3.9.3
 ",com.apptasticsoftware.rssreader.module.itunes;uses:="com.apptastics
 oftware.rssreader";version="3.9.3",com.apptasticsoftware.rssreader.mo
 dule.mediarss;uses:="com.apptasticsoftware.rssreader";version="3.9.3"
 ,com.apptasticsoftware.rssreader.util;uses:="com.apptasticsoftware.rs
 sreader";version="3.9.3"
Implementation-Title: RSS Reader
Implementation-Version: 3.9.3
Import-Package: java.io,java.lang,java.lang.invoke,java.lang.ref,java.
 net,java.net.http,java.nio.charset,java.security,java.time,java.time.
 format,java.util,java.util.concurrent,java.util.concurrent.atomic,jav
 a.util.function,java.util.logging,java.util.stream,java.util.zip,java
 x.net.ssl,javax.xml.stream
Require-Capability: osgi.ee;filter:="(&(osgi.ee=JavaSE)(version=11))"
Specification-Title: RSS Reader
Specification-Version: 3.9.3
Tool: Bnd-7.1.0.202411251545
```