### PR TITLE
Unhandled timestamp format

### DIFF
--- a/src/main/java/com/apptasticsoftware/rssreader/DateTime.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/DateTime.java
@@ -219,7 +219,7 @@ public class DateTime implements DateTimeParser {
             LocalDateTime localDateTime = LocalDateTime.parse(dateTime, formatter);
             return ZonedDateTime.of(localDateTime, defaultZone);
         } else if (((dateTime.length() == 29 || dateTime.length() == 32 || dateTime.length() == 35) && dateTime.charAt(10) == 'T') ||
-            ((dateTime.length() == 24 || dateTime.length() == 25) && dateTime.charAt(3) == ',')) {
+            ((dateTime.length() == 23 || dateTime.length() == 24 || dateTime.length() == 25) && dateTime.charAt(3) == ',')) {
             return ZonedDateTime.parse(dateTime, formatter);
         }
 
@@ -339,7 +339,7 @@ public class DateTime implements DateTimeParser {
         }
         else if ((dateTime.length() == 26 || dateTime.length() == 27) && dateTime.charAt(3) == ',' && dateTime.endsWith(" Z"))
             return RFC_1123_DATE_TIME_SPECIAL;
-        else if ((dateTime.length() == 24 || dateTime.length() == 25) && dateTime.charAt(3) == ',')
+        else if ((dateTime.length() == 23 || dateTime.length() == 24 || dateTime.length() == 25) && dateTime.charAt(3) == ',')
             return RFC_1123_DATE_TIME_NO_TIMEZONE;
         else
             return null;

--- a/src/test/java/com/apptasticsoftware/rssreader/DateTimeTest.java
+++ b/src/test/java/com/apptasticsoftware/rssreader/DateTimeTest.java
@@ -112,6 +112,9 @@ class DateTimeTest {
 
         timestamp = dateTime.toEpochMilli("Sun, 4 Sep 2022 09:42:16");
         assertEquals(1662284536000L, timestamp);
+
+        timestamp = dateTime.toEpochMilli("Sat, 2 Aug 2025 7:15:12");
+        assertEquals(1754118912000L, timestamp);
     }
 
     @Test


### PR DESCRIPTION
Unhandled timestamp format (one digit for the hour):
`Sat, 2 Aug 2025 7:15:12`

This bug affects code that calls `sorted()` or calls getters that return `ZonedDateTime`