### PR TITLE
Add feed filtering functionality

### DIFF
--- a/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
@@ -23,12 +23,11 @@
  */
 package com.apptasticsoftware.rssreader;
 
-import com.apptasticsoftware.rssreader.internal.StreamUtil;
+import com.apptasticsoftware.rssreader.filter.FeedFilter;
+import com.apptasticsoftware.rssreader.internal.*;
 import com.apptasticsoftware.rssreader.internal.stream.AutoCloseStream;
 import com.apptasticsoftware.rssreader.util.Default;
 import com.apptasticsoftware.rssreader.util.Mapper;
-import com.apptasticsoftware.rssreader.internal.DaemonThreadFactory;
-import com.apptasticsoftware.rssreader.internal.XMLInputFactorySecurity;
 
 import javax.net.ssl.SSLContext;
 import javax.xml.stream.XMLInputFactory;
@@ -74,6 +73,7 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
     private final HttpClient httpClient;
     private DateTimeParser dateTimeParser = Default.getDateTimeParser();
     private String userAgent = "";
+    private List<FeedFilter> feedFilters;
     private Duration connectionTimeout = Duration.ofSeconds(25);
     private Duration requestTimeout = Duration.ofSeconds(25);
     private Duration readTimeout = Duration.ofSeconds(25);
@@ -279,7 +279,19 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
     }
 
     /**
-     * Adds a http header to the http client.
+     * Adds a feed filter to process the feed input stream before parsing.
+     * @return updated RSSReader.
+     */
+    public AbstractRssReader<C, I> addFeedFilter(FeedFilter feedFilter) {
+        if (feedFilters == null) {
+            feedFilters = new ArrayList<>();
+        }
+        feedFilters.add(feedFilter);
+        return this;
+    }
+
+    /**
+     * Adds an http header to the http client.
      * @param key the key name of the header.
      * @param value the value of the header.
      * @return updated RSSReader.
@@ -648,6 +660,10 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
                 var xmlInputFactory = XMLInputFactorySecurity.hardenFactory(XMLInputFactory.newInstance());
                 xmlInputFactory.setProperty(XMLInputFactory.IS_COALESCING, true);
                 xmlInputFactory.setProperty(XMLInputFactory.IS_NAMESPACE_AWARE, false);
+
+                for (FeedFilter feedFilter : Optional.ofNullable(feedFilters).orElse(List.of())) {
+                    is = feedFilter.filter(is);
+                }
 
                 reader = xmlInputFactory.createXMLStreamReader(is);
                 cleanable = CLEANER.register(this, new CleaningAction(reader, is));

--- a/src/main/java/com/apptasticsoftware/rssreader/filter/FeedFilter.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/filter/FeedFilter.java
@@ -1,0 +1,19 @@
+package com.apptasticsoftware.rssreader.filter;
+
+import java.io.InputStream;
+
+/**
+ * An interface for filtering RSS or Atom feed streams. This filter can
+ * modify or clean feed data before it is processed by the feed parser,
+ * which maps it to {@link com.apptasticsoftware.rssreader.Item} objects.
+ */
+public interface FeedFilter {
+
+    /**
+     * Filters the provided XML feed stream.
+     *
+     * @param feedStream the input stream of the feed to be filtered
+     * @return a filtered input stream
+     */
+    InputStream filter(InputStream feedStream);
+}

--- a/src/main/java/module-info.java
+++ b/src/main/java/module-info.java
@@ -34,4 +34,5 @@ module com.apptasticsoftware.rssreader {
     exports com.apptasticsoftware.rssreader.util;
     exports com.apptasticsoftware.rssreader.module.itunes;
     exports com.apptasticsoftware.rssreader.module.mediarss;
+    exports com.apptasticsoftware.rssreader.filter;
 }


### PR DESCRIPTION
This PR adds feed filtering functionality by introducing a `FeedFilter` interface. A filter can modify or transform a feed before it is parsed into `Item` objects.

The feed filter is added to the `RssReader` by calling the `addFeedFilter` method.

Example:
```java
var list = new RssReader()
        .addFeedFilter(new InvalidXmlCharacterFilter())
        .read(fileInputSteam)
        .collect(Collectors.toList());
```
