### PR TITLE
Add mapping for RDF image

### DIFF
--- a/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
+++ b/src/main/java/com/apptasticsoftware/rssreader/AbstractRssReader.java
@@ -189,6 +189,9 @@ public abstract class AbstractRssReader<C extends Channel, I extends Item> {
         channelTags.putIfAbsent("/rss/channel/image/description", (channel, value) -> createIfNullOptional(channel::getImage, channel::setImage, Image::new).ifPresent(i -> i.setDescription(value)));
         channelTags.putIfAbsent("/rss/channel/image/height", (channel, value) -> createIfNullOptional(channel::getImage, channel::setImage, Image::new).ifPresent(i -> mapInteger(value, i::setHeight)));
         channelTags.putIfAbsent("/rss/channel/image/width", (channel, value) -> createIfNullOptional(channel::getImage, channel::setImage, Image::new).ifPresent(i -> mapInteger(value, i::setWidth)));
+        channelTags.putIfAbsent("/rdf:RDF/image/link", (channel, value) -> createIfNull(channel::getImage, channel::setImage, Image::new).setLink(value));
+        channelTags.putIfAbsent("/rdf:RDF/image/title", (channel, value) -> createIfNull(channel::getImage, channel::setImage, Image::new).setTitle(value));
+        channelTags.putIfAbsent("/rdf:RDF/image/url", (channel, value) -> createIfNull(channel::getImage, channel::setImage, Image::new).setUrl(value));
         channelTags.putIfAbsent("dc:language", (channel, value) -> Mapper.mapIfEmpty(value, channel::getLanguage, channel::setLanguage));
         channelTags.putIfAbsent("dc:rights", (channel, value) -> Mapper.mapIfEmpty(value, channel::getCopyright, channel::setCopyright));
         channelTags.putIfAbsent("dc:title", (channel, value) -> Mapper.mapIfEmpty(value, channel::getTitle, channel::setTitle));

--- a/src/test/java/com/apptasticsoftware/integrationtest/RdfFeedTest.java
+++ b/src/test/java/com/apptasticsoftware/integrationtest/RdfFeedTest.java
@@ -1,0 +1,69 @@
+package com.apptasticsoftware.integrationtest;
+
+import com.apptasticsoftware.rssreader.RssReader;
+import com.apptasticsoftware.rssreader.util.Default;
+import org.junit.jupiter.api.Test;
+
+import java.io.InputStream;
+import java.util.stream.Collectors;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class RdfFeedTest {
+
+    @Test
+    void readRdfFeedExample1() {
+        var list = new RssReader().read(fromFile("rdf-feed-example1.xml")).collect(Collectors.toList());
+        assertEquals(9, list.size());
+        var item = list.get(0);
+        var channel = item.getChannel();
+
+        assertTrue(channel.getImage().isPresent());
+        assertEquals("Journal of Web Librarianship", channel.getImage().get().getTitle());
+        assertEquals("https://www.tandfonline.com/loi/wjwl20?ai=1dl&mi=el63dh&af=R", channel.getImage().get().getLink());
+        assertEquals("https://www.tandfonline.com/cms/asset/66f7625d-e646-4c24-a36d-18dcf406d2ad/default_cover.jpg", channel.getImage().get().getUrl());
+
+        assertEquals("tandf: Journal of Web Librarianship: Table of Contents", item.getChannel().getTitle());
+        assertEquals("Table of Contents for Journal of Web Librarianship. List of articles from both the latest and ahead of print issues.", item.getChannel().getDescription());
+        assertEquals("en-US", item.getChannel().getLanguage().orElse(""));
+        assertEquals("I Can’t Get No Satis-Searching: Reassessing Discovery Layers in Academic Libraries Journal of Web Librarianship", item.getTitle().orElse(""));
+        assertEquals("Volume 18, Issue 1, January-March 2024, Page 1-14<br/>. <br/>", item.getDescription().orElse(""));
+        assertEquals("doi:10.1080/19322909.2024.2326687", item.getGuid().orElse(""));
+    }
+
+    @Test
+    void readRdfFeedExample2() {
+        var list = new RssReader().read(fromFile("rdf-feed-example2.xml")).collect(Collectors.toList());
+        assertEquals(1, list.size());
+        var item = list.get(0);
+        var channel = item.getChannel();
+
+        assertTrue(channel.getImage().isPresent());
+        assertEquals("Slashdot", channel.getImage().get().getTitle());
+        assertEquals("http://slashdot.org", channel.getImage().get().getLink());
+        assertEquals("http://images.slashdot.org/topics/topicslashdot.gif", channel.getImage().get().getUrl());
+
+        assertEquals("Slashdot", item.getChannel().getTitle());
+        assertEquals("News for nerds, stuff that matters", item.getChannel().getDescription());
+        assertEquals("http://slashdot.org", item.getChannel().getLink());
+        assertEquals("en-us", item.getChannel().getLanguage().orElse(""));
+        assertEquals("pater@slashdot.org", item.getChannel().getManagingEditor().orElse(""));
+        assertEquals("Copyright © 2000 Slashdot", item.getChannel().getCopyright().orElse(""));
+        assertEquals("2000-12-17T01:17-05:00", item.getChannel().getPubDate().orElse(""));
+        assertEquals(Default.getDateTimeParser().parse("2000-12-17T01:17-05:00"), item.getChannel().getPubDateZonedDateTime().orElse(null));
+
+        assertEquals("Jupiter Moon Ganymede May Have An Ocean", item.getTitle().orElse(""));
+        assertEquals("http://slashdot.org/article.pl?sid=00/12/17/0622203", item.getLink().orElse(""));
+        assertEquals("This article talks about how Jupiter's moon, Ganymede, may have a\n" +
+                "            salt water ocean on it. Kind of ...", item.getDescription().orElse(""));
+        assertEquals("timothy", item.getAuthor().orElse(""));
+        assertEquals("2000-12-17T01:17", item.getPubDate().orElse(""));
+        assertEquals(Default.getDateTimeParser().parse("2000-12-17T01:17"), item.getPubDateZonedDateTime().orElse(null));
+        assertEquals(1, item.getCategories().size());
+        assertEquals("space", item.getCategories().get(0));
+    }
+
+    private InputStream fromFile(String fileName) {
+        return getClass().getClassLoader().getResourceAsStream(fileName);
+    }
+}

--- a/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
+++ b/src/test/java/com/apptasticsoftware/integrationtest/RssReaderIntegrationTest.java
@@ -1,7 +1,6 @@
 package com.apptasticsoftware.integrationtest;
 
 import com.apptasticsoftware.rssreader.*;
-import com.apptasticsoftware.rssreader.util.Default;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -810,45 +809,6 @@ class RssReaderIntegrationTest {
         var item = list.get(0);
         assertEquals("NYT > channel description", item.getChannel().getDescription());
         assertEquals("NYT > image description", item.getChannel().getImage().map(image -> image.getDescription().orElse("")).orElse(""));
-    }
-
-    @Test
-    void readRdfFeedExample1() {
-        var list = new RssReader().read(fromFile("rdf-feed-example1.xml")).collect(Collectors.toList());
-        assertEquals(9, list.size());
-        var item = list.get(0);
-        assertEquals("tandf: Journal of Web Librarianship: Table of Contents", item.getChannel().getTitle());
-        assertEquals("Table of Contents for Journal of Web Librarianship. List of articles from both the latest and ahead of print issues.", item.getChannel().getDescription());
-        assertEquals("en-US", item.getChannel().getLanguage().orElse(""));
-        assertEquals("I Can’t Get No Satis-Searching: Reassessing Discovery Layers in Academic Libraries Journal of Web Librarianship", item.getTitle().orElse(""));
-        assertEquals("Volume 18, Issue 1, January-March 2024, Page 1-14<br/>. <br/>", item.getDescription().orElse(""));
-        assertEquals("doi:10.1080/19322909.2024.2326687", item.getGuid().orElse(""));
-    }
-
-    @Test
-    void readRdfFeedExample2() {
-        var list = new RssReader().read(fromFile("rdf-feed-example2.xml")).collect(Collectors.toList());
-        assertEquals(1, list.size());
-        var item = list.get(0);
-
-        assertEquals("Slashdot", item.getChannel().getTitle());
-        assertEquals("News for nerds, stuff that matters", item.getChannel().getDescription());
-        assertEquals("http://slashdot.org", item.getChannel().getLink());
-        assertEquals("en-us", item.getChannel().getLanguage().orElse(""));
-        assertEquals("pater@slashdot.org", item.getChannel().getManagingEditor().orElse(""));
-        assertEquals("Copyright © 2000 Slashdot", item.getChannel().getCopyright().orElse(""));
-        assertEquals("2000-12-17T01:17-05:00", item.getChannel().getPubDate().orElse(""));
-        assertEquals(Default.getDateTimeParser().parse("2000-12-17T01:17-05:00"), item.getChannel().getPubDateZonedDateTime().orElse(null));
-
-        assertEquals("Jupiter Moon Ganymede May Have An Ocean", item.getTitle().orElse(""));
-        assertEquals("http://slashdot.org/article.pl?sid=00/12/17/0622203", item.getLink().orElse(""));
-        assertEquals("This article talks about how Jupiter's moon, Ganymede, may have a\n" +
-                "            salt water ocean on it. Kind of ...", item.getDescription().orElse(""));
-        assertEquals("timothy", item.getAuthor().orElse(""));
-        assertEquals("2000-12-17T01:17", item.getPubDate().orElse(""));
-        assertEquals(Default.getDateTimeParser().parse("2000-12-17T01:17"), item.getPubDateZonedDateTime().orElse(null));
-        assertEquals(1, item.getCategories().size());
-        assertEquals("space", item.getCategories().get(0));
     }
 
     @Test


### PR DESCRIPTION
Add mapping for the image tag in the RDF feed.

/rdf:RDF/image/title -> channel.image().getTitle()
/rdf:RDF/image/link -> channel.image().getLink()
/rdf:RDF/image/url -> channel.image().getUrl()

```xml
<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns="http://purl.org/rss/1.0/">
	<channel rdf:about="http://www.xml.com/xml/news.rss">
		...
	</channel>
	<image rdf:about="http://xml.com/universal/images/xml_tiny.gif">
		<title>XML.com</title>
		<link>http://www.xml.com</link>
		<url>http://xml.com/universal/images/xml_tiny.gif</url>
	</image>
	<item rdf:about="http://xml.com/pub/2000/08/09/xslt/xslt.html">
		...
	</item>
	<item rdf:about="http://xml.com/pub/2000/08/09/rdfdb/index.html">
		...
	</item>
</rdf:RDF>
```